### PR TITLE
UPClientZenoh should store the UUIDBuilder and reuse it.

### DIFF
--- a/examples/publisher.rs
+++ b/examples/publisher.rs
@@ -17,7 +17,6 @@ use up_client_zenoh::UPClientZenoh;
 use up_rust::{
     transport::{builder::UMessageBuilder, datamodel::UTransport},
     uprotocol::{UEntity, UPayloadFormat, UResource, UUri},
-    uuid::builder::UUIDBuilder,
 };
 use zenoh::config::Config;
 
@@ -55,7 +54,7 @@ async fn main() {
         let data = format!("{cnt}");
         let umessage = UMessageBuilder::publish(&uuri)
             .build_with_payload(
-                &UUIDBuilder::new(),
+                publisher.get_uuid_builder(),
                 data.as_bytes().to_vec().into(),
                 UPayloadFormat::UPAYLOAD_FORMAT_TEXT,
             )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,10 @@ use std::{
     collections::HashMap,
     sync::{atomic::AtomicU64, Arc, Mutex},
 };
-use up_rust::uprotocol::{UAttributes, UCode, UMessage, UPayloadFormat, UPriority, UStatus, UUri};
+use up_rust::{
+    uprotocol::{UAttributes, UCode, UMessage, UPayloadFormat, UPriority, UStatus, UUri},
+    uuid::builder::UUIDBuilder,
+};
 use zenoh::{
     config::Config,
     prelude::r#async::*,
@@ -43,7 +46,10 @@ pub struct UPClientZenoh {
     query_map: Arc<Mutex<HashMap<String, Query>>>,
     // Save the callback for RPC response
     rpc_callback_map: Arc<Mutex<HashMap<String, Arc<UtransportListener>>>>,
+    // Used to identify different callbacks
     callback_counter: AtomicU64,
+    // UUID builder
+    uuid_builder: UUIDBuilder,
 }
 
 impl UPClientZenoh {
@@ -63,7 +69,12 @@ impl UPClientZenoh {
             query_map: Arc::new(Mutex::new(HashMap::new())),
             rpc_callback_map: Arc::new(Mutex::new(HashMap::new())),
             callback_counter: AtomicU64::new(0),
+            uuid_builder: UUIDBuilder::new(),
         })
+    }
+
+    pub fn get_uuid_builder(&self) -> &UUIDBuilder {
+        &self.uuid_builder
     }
 
     fn get_uauth_from_uuri(uri: &UUri) -> Result<String, UStatus> {

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -19,7 +19,6 @@ use up_rust::{
     transport::{builder::UMessageBuilder, datamodel::UTransport},
     uprotocol::{Data, UMessage, UPayload, UStatus, UUri},
     uri::{builder::resourcebuilder::UResourceBuilder, validator::UriValidator},
-    uuid::builder::UUIDBuilder,
 };
 use zenoh::prelude::r#async::*;
 
@@ -52,8 +51,7 @@ impl RpcClient for UPClientZenoh {
         };
 
         // Generate UAttributes
-        let uuid_builder = UUIDBuilder::new();
-        let reqid = UUIDBuilder::new().build();
+        let reqid = self.uuid_builder.build();
         // Create response address
         let mut source = topic.clone();
         source.resource = Some(UResourceBuilder::for_rpc_response()).into();
@@ -61,9 +59,9 @@ impl RpcClient for UPClientZenoh {
         let umessage = if let Some(token) = options.token() {
             UMessageBuilder::request(&topic, &source, &reqid, 255)
                 .with_token(&token.to_string())
-                .build(&uuid_builder)
+                .build(&self.uuid_builder)
         } else {
-            UMessageBuilder::request(&topic, &source, &reqid, 255).build(&uuid_builder)
+            UMessageBuilder::request(&topic, &source, &reqid, 255).build(&self.uuid_builder)
         };
         // Extract uAttributes
         let Ok(UMessage {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -22,7 +22,6 @@ use up_rust::{
         UPayload, UPayloadFormat, UResource, UStatus, UUri,
     },
     uri::builder::resourcebuilder::UResourceBuilder,
-    uuid::builder::UUIDBuilder,
 };
 use zenoh::config::Config;
 
@@ -225,7 +224,7 @@ async fn test_publish_and_subscribe() {
 
     let umessage = UMessageBuilder::publish(&uuri)
         .build_with_payload(
-            &UUIDBuilder::new(),
+            upclient.get_uuid_builder(),
             target_data.as_bytes().to_vec().into(),
             UPayloadFormat::UPAYLOAD_FORMAT_TEXT,
         )
@@ -270,7 +269,7 @@ async fn test_notification_and_subscribe() {
 
     let umessage = UMessageBuilder::notification(&uuri)
         .build_with_payload(
-            &UUIDBuilder::new(),
+            upclient.get_uuid_builder(),
             target_data.as_bytes().to_vec().into(),
             UPayloadFormat::UPAYLOAD_FORMAT_TEXT,
         )
@@ -435,7 +434,7 @@ async fn test_register_listener_with_special_uuri() {
 
         let umessage = UMessageBuilder::publish(&publish_uuri)
             .build_with_payload(
-                &UUIDBuilder::new(),
+                upclient2.get_uuid_builder(),
                 publish_data.as_bytes().to_vec().into(),
                 UPayloadFormat::UPAYLOAD_FORMAT_TEXT,
             )


### PR DESCRIPTION
Solve #10 
UPClientZenoh should reuse its UUIDBuilder and keep the consistency of the UUID (lsb part).