### PR TITLE
Use `up-rust` with `UListener` trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,8 @@ log = "0.4.17"
 prost = "0.12"
 prost-types = "0.12"
 protobuf = { version = "3.3" }
-up-rust = { git = "https://github.com/eclipse-uprotocol/up-rust", rev = "68c8a1d94f0006daf4ba135c9cbbfddcd793108d" }
+# upstream
+# up-rust = { git = "https://github.com/eclipse-uprotocol/up-rust", rev = "68c8a1d94f0006daf4ba135c9cbbfddcd793108d" }
+# feature/ulistener_generics
+up-rust = { git = "https://github.com/PLeVasseur/uprotocol-rust_fork", branch = "feature/ulistener_generics" }
 zenoh = { version = "0.10.1-rc", features = ["unstable"]}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,8 @@ use std::{
     collections::HashMap,
     sync::{atomic::AtomicU64, Arc, Mutex},
 };
-use up_rust::uprotocol::{UAttributes, UCode, UMessage, UPayloadFormat, UPriority, UStatus, UUri};
+use up_rust::listener_wrapper::ListenerWrapper;
+use up_rust::{UAttributes, UCode, UPayloadFormat, UPriority, UStatus, UUri};
 use zenoh::{
     config::Config,
     prelude::r#async::*,
@@ -28,21 +29,19 @@ use zenoh::{
     subscriber::Subscriber,
 };
 
-pub type UtransportListener = Box<dyn Fn(Result<UMessage, UStatus>) + Send + Sync + 'static>;
-
 const UATTRIBUTE_VERSION: u8 = 1;
 
 pub struct ZenohListener {}
 pub struct UPClientZenoh {
     session: Arc<Session>,
     // Able to unregister Subscriber
-    subscriber_map: Arc<Mutex<HashMap<String, Subscriber<'static, ()>>>>,
+    subscriber_map: Arc<Mutex<HashMap<Arc<ListenerWrapper>, Subscriber<'static, ()>>>>,
     // Able to unregister Queryable
-    queryable_map: Arc<Mutex<HashMap<String, Queryable<'static, ()>>>>,
+    queryable_map: Arc<Mutex<HashMap<Arc<ListenerWrapper>, Queryable<'static, ()>>>>,
     // Save the reqid to be able to send back response
     query_map: Arc<Mutex<HashMap<String, Query>>>,
     // Save the callback for RPC response
-    rpc_callback_map: Arc<Mutex<HashMap<String, Arc<UtransportListener>>>>,
+    rpc_callback_map: Arc<Mutex<HashMap<UUri, Arc<ListenerWrapper>>>>,
     callback_counter: AtomicU64,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,7 +181,7 @@ impl UPClientZenoh {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use up_rust::uprotocol::{uri::uauthority::Number, UAuthority, UEntity, UResource, UUri};
+    use up_rust::{Number, UAuthority, UEntity, UResource, UUri};
 
     #[test]
     fn test_to_zenoh_key_string() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ use protobuf::{Enum, Message};
 use std::collections::HashSet;
 use std::{
     collections::HashMap,
-    sync::{atomic::AtomicU64, Arc, Mutex},
+    sync::{Arc, Mutex},
 };
 use up_rust::listener_wrapper::ListenerWrapper;
 use up_rust::{UAttributes, UCode, UPayloadFormat, UPriority, UStatus, UUri};
@@ -36,15 +36,16 @@ pub struct ZenohListener {}
 pub struct UPClientZenoh {
     session: Arc<Session>,
     // Able to unregister Subscriber
+    #[allow(clippy::type_complexity)]
     subscriber_map:
         Arc<Mutex<HashMap<UUri, HashMap<Arc<ListenerWrapper>, Subscriber<'static, ()>>>>>,
     // Able to unregister Queryable
+    #[allow(clippy::type_complexity)]
     queryable_map: Arc<Mutex<HashMap<UUri, HashMap<Arc<ListenerWrapper>, Queryable<'static, ()>>>>>,
     // Save the reqid to be able to send back response
     query_map: Arc<Mutex<HashMap<String, Query>>>,
     // Save the callback for RPC response
     rpc_callback_map: Arc<Mutex<HashMap<UUri, HashSet<Arc<ListenerWrapper>>>>>,
-    callback_counter: AtomicU64,
 }
 
 impl UPClientZenoh {
@@ -63,7 +64,6 @@ impl UPClientZenoh {
             queryable_map: Arc::new(Mutex::new(HashMap::new())),
             query_map: Arc::new(Mutex::new(HashMap::new())),
             rpc_callback_map: Arc::new(Mutex::new(HashMap::new())),
-            callback_counter: AtomicU64::new(0),
         })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod rpc;
 pub mod utransport;
 
 use protobuf::{Enum, Message};
+use std::collections::HashSet;
 use std::{
     collections::HashMap,
     sync::{atomic::AtomicU64, Arc, Mutex},
@@ -35,13 +36,14 @@ pub struct ZenohListener {}
 pub struct UPClientZenoh {
     session: Arc<Session>,
     // Able to unregister Subscriber
-    subscriber_map: Arc<Mutex<HashMap<Arc<ListenerWrapper>, Subscriber<'static, ()>>>>,
+    subscriber_map:
+        Arc<Mutex<HashMap<UUri, HashMap<Arc<ListenerWrapper>, Subscriber<'static, ()>>>>>,
     // Able to unregister Queryable
-    queryable_map: Arc<Mutex<HashMap<Arc<ListenerWrapper>, Queryable<'static, ()>>>>,
+    queryable_map: Arc<Mutex<HashMap<UUri, HashMap<Arc<ListenerWrapper>, Queryable<'static, ()>>>>>,
     // Save the reqid to be able to send back response
     query_map: Arc<Mutex<HashMap<String, Query>>>,
     // Save the callback for RPC response
-    rpc_callback_map: Arc<Mutex<HashMap<UUri, Arc<ListenerWrapper>>>>,
+    rpc_callback_map: Arc<Mutex<HashMap<UUri, HashSet<Arc<ListenerWrapper>>>>>,
     callback_counter: AtomicU64,
 }
 

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -11,141 +11,135 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use crate::UPClientZenoh;
-use async_trait::async_trait;
-use std::{string::ToString, time::Duration};
-use up_rust::{
-    rpc::{CallOptions, RpcClient, RpcClientResult, RpcMapperError, RpcServer},
-    transport::{builder::UMessageBuilder, datamodel::UTransport},
-    uprotocol::{Data, UMessage, UPayload, UStatus, UUri},
-    uri::{builder::resourcebuilder::UResourceBuilder, validator::UriValidator},
-    uuid::builder::UUIDBuilder,
-};
-use zenoh::prelude::r#async::*;
-
-// TODO: Need to check how to use CallOptions
-#[async_trait]
-impl RpcClient for UPClientZenoh {
-    async fn invoke_method(
-        &self,
-        topic: UUri,
-        payload: UPayload,
-        options: CallOptions,
-    ) -> RpcClientResult {
-        // Validate UUri
-        UriValidator::validate(&topic)
-            .map_err(|_| RpcMapperError::UnexpectedError(String::from("Wrong UUri")))?;
-
-        // Get Zenoh key
-        let Ok(zenoh_key) = UPClientZenoh::to_zenoh_key_string(&topic) else {
-            return Err(RpcMapperError::UnexpectedError(String::from(
-                "Unable to transform to Zenoh key",
-            )));
-        };
-
-        // Get the data from UPayload
-        let buf = if let Some(Data::Value(buf)) = payload.data {
-            buf
-        } else {
-            // TODO: Assume we only have Value here, no reference for shared memory
-            vec![]
-        };
-
-        // Generate UAttributes
-        let uuid_builder = UUIDBuilder::new();
-        let reqid = UUIDBuilder::new().build();
-        // Create response address
-        let mut source = topic.clone();
-        source.resource = Some(UResourceBuilder::for_rpc_response()).into();
-        // TODO: Check the ttl
-        let umessage = if let Some(token) = options.token() {
-            UMessageBuilder::request(&topic, &source, &reqid, 255)
-                .with_token(&token.to_string())
-                .build(&uuid_builder)
-        } else {
-            UMessageBuilder::request(&topic, &source, &reqid, 255).build(&uuid_builder)
-        };
-        // Extract uAttributes
-        let Ok(UMessage {
-            attributes: uattributes,
-            ..
-        }) = umessage
-        else {
-            return Err(RpcMapperError::UnexpectedError(String::from(
-                "Unable to create uAttributes",
-            )));
-        };
-        // Put into attachment
-        let Ok(attachment) = UPClientZenoh::uattributes_to_attachment(&uattributes) else {
-            return Err(RpcMapperError::UnexpectedError(String::from(
-                "Invalid uAttributes",
-            )));
-        };
-
-        let value = Value::new(buf.into()).encoding(Encoding::WithSuffix(
-            KnownEncoding::AppCustom,
-            payload.format.value().to_string().into(),
-        ));
-        // TODO: Query should support .encoding
-        // TODO: Adjust the timeout
-        let getbuilder = self
-            .session
-            .get(&zenoh_key)
-            .with_value(value)
-            .with_attachment(attachment.build())
-            .target(QueryTarget::BestMatching)
-            .timeout(Duration::from_millis(1000));
-
-        // Send the query
-        let Ok(replies) = getbuilder.res().await else {
-            return Err(RpcMapperError::UnexpectedError(String::from(
-                "Error while sending Zenoh query",
-            )));
-        };
-
-        let Ok(reply) = replies.recv_async().await else {
-            return Err(RpcMapperError::UnexpectedError(String::from(
-                "Error while receiving Zenoh reply",
-            )));
-        };
-        match reply.sample {
-            Ok(sample) => {
-                let Some(encoding) = UPClientZenoh::to_upayload_format(&sample.encoding) else {
-                    return Err(RpcMapperError::UnexpectedError(String::from(
-                        "Error while parsing Zenoh encoding",
-                    )));
-                };
-                // TODO: Need to check attributes is correct or not
-                Ok(UMessage {
-                    attributes: uattributes,
-                    payload: Some(UPayload {
-                        length: Some(0),
-                        format: encoding.into(),
-                        data: Some(Data::Value(sample.payload.contiguous().to_vec())),
-                        ..Default::default()
-                    })
-                    .into(),
-                    ..Default::default()
-                })
-            }
-            Err(e) => Err(RpcMapperError::UnexpectedError(format!(
-                "Error while parsing Zenoh reply: {e:?}"
-            ))),
-        }
-    }
-}
-
-#[async_trait]
-impl RpcServer for UPClientZenoh {
-    async fn register_rpc_listener(
-        &self,
-        method: UUri,
-        listener: Box<dyn Fn(Result<UMessage, UStatus>) + Send + Sync + 'static>,
-    ) -> Result<String, UStatus> {
-        self.register_listener(method, listener).await
-    }
-
-    async fn unregister_rpc_listener(&self, method: UUri, listener: &str) -> Result<(), UStatus> {
-        self.unregister_listener(method, listener).await
-    }
-}
+// use crate::UPClientZenoh;
+// use async_trait::async_trait;
+// use std::{string::ToString, time::Duration};
+// use up_rust::{CallOptions, Data, RpcClient, RpcClientResult, RpcMapperError, RpcServer, UMessage, UPayload, UResourceBuilder, UriValidator, UStatus, UUri, UMessageBuilder, UTransport, UUIDBuilder};
+// use zenoh::prelude::r#async::*;
+//
+// // TODO: Need to check how to use CallOptions
+// #[async_trait]
+// impl RpcClient for UPClientZenoh {
+//     async fn invoke_method(
+//         &self,
+//         topic: UUri,
+//         payload: UPayload,
+//         options: CallOptions,
+//     ) -> RpcClientResult {
+//         // Validate UUri
+//         UriValidator::validate(&topic)
+//             .map_err(|_| RpcMapperError::UnexpectedError(String::from("Wrong UUri")))?;
+//
+//         // Get Zenoh key
+//         let Ok(zenoh_key) = UPClientZenoh::to_zenoh_key_string(&topic) else {
+//             return Err(RpcMapperError::UnexpectedError(String::from(
+//                 "Unable to transform to Zenoh key",
+//             )));
+//         };
+//
+//         // Get the data from UPayload
+//         let buf = if let Some(Data::Value(buf)) = payload.data {
+//             buf
+//         } else {
+//             // TODO: Assume we only have Value here, no reference for shared memory
+//             vec![]
+//         };
+//
+//         // Generate UAttributes
+//         let uuid_builder = UUIDBuilder::new();
+//         let reqid = UUIDBuilder::new().build();
+//         // Create response address
+//         let mut source = topic.clone();
+//         source.resource = Some(UResourceBuilder::for_rpc_response()).into();
+//         // TODO: Check the ttl
+//         let umessage = if let Some(token) = options.token() {
+//             UMessageBuilder::request(&topic, &source, &reqid, 255)
+//                 .with_token(&token.to_string())
+//                 .build(&uuid_builder)
+//         } else {
+//             UMessageBuilder::request(&topic, &source, &reqid, 255).build(&uuid_builder)
+//         };
+//         // Extract uAttributes
+//         let Ok(UMessage {
+//             attributes: uattributes,
+//             ..
+//         }) = umessage
+//         else {
+//             return Err(RpcMapperError::UnexpectedError(String::from(
+//                 "Unable to create uAttributes",
+//             )));
+//         };
+//         // Put into attachment
+//         let Ok(attachment) = UPClientZenoh::uattributes_to_attachment(&uattributes) else {
+//             return Err(RpcMapperError::UnexpectedError(String::from(
+//                 "Invalid uAttributes",
+//             )));
+//         };
+//
+//         let value = Value::new(buf.into()).encoding(Encoding::WithSuffix(
+//             KnownEncoding::AppCustom,
+//             payload.format.value().to_string().into(),
+//         ));
+//         // TODO: Query should support .encoding
+//         // TODO: Adjust the timeout
+//         let getbuilder = self
+//             .session
+//             .get(&zenoh_key)
+//             .with_value(value)
+//             .with_attachment(attachment.build())
+//             .target(QueryTarget::BestMatching)
+//             .timeout(Duration::from_millis(1000));
+//
+//         // Send the query
+//         let Ok(replies) = getbuilder.res().await else {
+//             return Err(RpcMapperError::UnexpectedError(String::from(
+//                 "Error while sending Zenoh query",
+//             )));
+//         };
+//
+//         let Ok(reply) = replies.recv_async().await else {
+//             return Err(RpcMapperError::UnexpectedError(String::from(
+//                 "Error while receiving Zenoh reply",
+//             )));
+//         };
+//         match reply.sample {
+//             Ok(sample) => {
+//                 let Some(encoding) = UPClientZenoh::to_upayload_format(&sample.encoding) else {
+//                     return Err(RpcMapperError::UnexpectedError(String::from(
+//                         "Error while parsing Zenoh encoding",
+//                     )));
+//                 };
+//                 // TODO: Need to check attributes is correct or not
+//                 Ok(UMessage {
+//                     attributes: uattributes,
+//                     payload: Some(UPayload {
+//                         length: Some(0),
+//                         format: encoding.into(),
+//                         data: Some(Data::Value(sample.payload.contiguous().to_vec())),
+//                         ..Default::default()
+//                     })
+//                     .into(),
+//                     ..Default::default()
+//                 })
+//             }
+//             Err(e) => Err(RpcMapperError::UnexpectedError(format!(
+//                 "Error while parsing Zenoh reply: {e:?}"
+//             ))),
+//         }
+//     }
+// }
+//
+// #[async_trait]
+// impl RpcServer for UPClientZenoh {
+//     async fn register_rpc_listener(
+//         &self,
+//         method: UUri,
+//         listener: Box<dyn Fn(Result<UMessage, UStatus>) + Send + Sync + 'static>,
+//     ) -> Result<String, UStatus> {
+//         self.register_listener(method, listener).await
+//     }
+//
+//     async fn unregister_rpc_listener(&self, method: UUri, listener: &str) -> Result<(), UStatus> {
+//         self.unregister_listener(method, listener).await
+//     }
+// }

--- a/src/utransport.rs
+++ b/src/utransport.rs
@@ -592,7 +592,7 @@ impl UTransport for UPClientZenoh {
                 .rpc_callback_map
                 .lock()
                 .unwrap()
-                .remove(&topic)
+                .remove(&topic) // TODO: I do not think we should be calling .remove here... we could blow up other listeners
                 .is_none()
             {
                 if message_type == UMessageType::UMESSAGE_TYPE_RESPONSE {
@@ -631,9 +631,9 @@ impl UTransport for UPClientZenoh {
                                 UCode::NOT_FOUND,
                                 format!("No listeners registered for topic: {:?}", &topic),
                             ));
-                        } else {
-                            found_authority = true;
                         }
+                    } else {
+                        found_authority = true;
                     }
                 }
             }
@@ -664,9 +664,9 @@ impl UTransport for UPClientZenoh {
                                 UCode::NOT_FOUND,
                                 format!("No listeners registered for topic: {:?}", &topic),
                             ));
-                        } else {
-                            found_authority = true;
                         }
+                    } else {
+                        found_authority = true;
                     }
                 }
             }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -14,15 +14,11 @@
 use async_std::task::{self, block_on};
 use std::{sync::Arc, time};
 use up_client_zenoh::UPClientZenoh;
+use up_rust::ulistener::UListener;
 use up_rust::{
-    rpc::{CallOptionsBuilder, RpcClient, RpcServer},
-    transport::{builder::UMessageBuilder, datamodel::UTransport},
-    uprotocol::{
-        uri::uauthority::Number, Data, UAuthority, UCode, UEntity, UMessage, UMessageType,
-        UPayload, UPayloadFormat, UResource, UStatus, UUri,
-    },
-    uri::builder::resourcebuilder::UResourceBuilder,
-    uuid::builder::UUIDBuilder,
+    CallOptionsBuilder, Data, Number, RpcClient, RpcServer, UAuthority, UCode, UEntity, UMessage,
+    UMessageBuilder, UMessageType, UPayload, UPayloadFormat, UResource, UResourceBuilder, UStatus,
+    UTransport, UUIDBuilder, UUri,
 };
 use zenoh::config::Config;
 
@@ -101,377 +97,388 @@ fn create_special_uuri() -> UUri {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+struct FooListener;
+
+impl UListener for FooListener {
+    fn on_receive(&self, received: Result<UMessage, UStatus>) {
+        println!("From within FooListener, received: {:?}", &received);
+    }
+}
+
 #[async_std::test]
 async fn test_utransport_register_and_unregister() {
     let upclient = UPClientZenoh::new(Config::default()).await.unwrap();
     let uuri = create_utransport_uuri(0);
 
-    // Compare the return string
-    let listener_string = upclient
-        .register_listener(uuri.clone(), Box::new(|_| {}))
-        .await
-        .unwrap();
-    assert_eq!(listener_string, "upl/0100162e04d20100_0");
+    let foo_listener_register = FooListener;
+    // Able to register
+    let register_res = upclient
+        .register_listener(uuri.clone(), foo_listener_register)
+        .await;
+    assert_eq!(register_res, Ok(()));
 
-    // Able to ungister
-    upclient
-        .unregister_listener(uuri.clone(), &listener_string)
-        .await
-        .unwrap();
+    let foo_listener_unregister = FooListener;
+    // Able to unregister
+    let unregister_res = upclient
+        .unregister_listener(uuri.clone(), foo_listener_unregister)
+        .await;
+    assert_eq!(unregister_res, Ok(()));
 
-    // Unable to ungister
+    let foo_listener_unregister = FooListener;
+    // Unable to unregister
     let result = upclient
-        .unregister_listener(uuri.clone(), &listener_string)
+        .unregister_listener(uuri.clone(), foo_listener_unregister)
         .await;
     assert_eq!(
         result,
         Err(UStatus::fail_with_code(
-            UCode::INVALID_ARGUMENT,
-            "Publish listener doesn't exist"
+            UCode::NOT_FOUND,
+            format!("No listeners registered for topic: {:?}", &uuri),
         ))
     );
 }
 
-#[async_std::test]
-async fn test_rpcserver_register_and_unregister() {
-    let upclient = UPClientZenoh::new(Config::default()).await.unwrap();
-    let uuri = create_rpcserver_uuri();
-
-    // Compare the return string
-    let listener_string = upclient
-        .register_rpc_listener(uuri.clone(), Box::new(|_| {}))
-        .await
-        .unwrap();
-    assert_eq!(listener_string, "upl/0100162e04d20100_0");
-
-    // Able to ungister
-    upclient
-        .unregister_rpc_listener(uuri.clone(), &listener_string)
-        .await
-        .unwrap();
-
-    // Unable to ungister
-    let result = upclient
-        .unregister_rpc_listener(uuri.clone(), &listener_string)
-        .await;
-    assert_eq!(
-        result,
-        Err(UStatus::fail_with_code(
-            UCode::INVALID_ARGUMENT,
-            "RPC request listener doesn't exist"
-        ))
-    );
-}
-
-#[async_std::test]
-async fn test_utransport_special_uuri_register_and_unregister() {
-    let upclient = UPClientZenoh::new(Config::default()).await.unwrap();
-    let uuri = create_special_uuri();
-
-    // Compare the return string
-    let listener_string = upclient
-        .register_listener(uuri.clone(), Box::new(|_| {}))
-        .await
-        .unwrap();
-    assert_eq!(
-        listener_string,
-        "upr/060102030a0b0c/**_0&upr/060102030a0b0c/**_1&upr/060102030a0b0c/**_2"
-    );
-
-    // Able to ungister
-    upclient
-        .unregister_listener(uuri.clone(), &listener_string)
-        .await
-        .unwrap();
-
-    // Unable to ungister
-    let result = upclient
-        .unregister_listener(uuri.clone(), &listener_string)
-        .await;
-    assert_eq!(
-        result,
-        Err(UStatus::fail_with_code(
-            UCode::INVALID_ARGUMENT,
-            "RPC response callback doesn't exist"
-        ))
-    );
-}
-
-#[async_std::test]
-async fn test_publish_and_subscribe() {
-    let target_data = String::from("Hello World!");
-    let upclient = UPClientZenoh::new(Config::default()).await.unwrap();
-    let uuri = create_utransport_uuri(0);
-
-    // Register the listener
-    let uuri_cloned = uuri.clone();
-    let data_cloned = target_data.clone();
-    let listener = move |result: Result<UMessage, UStatus>| match result {
-        Ok(msg) => {
-            if let Data::Value(v) = msg.payload.unwrap().data.unwrap() {
-                let value = v.into_iter().map(|c| c as char).collect::<String>();
-                assert_eq!(msg.attributes.unwrap().source.unwrap(), uuri_cloned);
-                assert_eq!(value, data_cloned);
-            } else {
-                panic!("The message should be Data::Value type.");
-            }
-        }
-        Err(ustatus) => panic!("Internal Error: {ustatus:?}"),
-    };
-    let listener_string = upclient
-        .register_listener(uuri.clone(), Box::new(listener))
-        .await
-        .unwrap();
-
-    let umessage = UMessageBuilder::publish(&uuri)
-        .build_with_payload(
-            &UUIDBuilder::new(),
-            target_data.as_bytes().to_vec().into(),
-            UPayloadFormat::UPAYLOAD_FORMAT_TEXT,
-        )
-        .unwrap();
-    upclient.send(umessage).await.unwrap();
-
-    // Waiting for the subscriber to receive data
-    task::sleep(time::Duration::from_millis(1000)).await;
-
-    // Cleanup
-    upclient
-        .unregister_listener(uuri.clone(), &listener_string)
-        .await
-        .unwrap();
-}
-
-#[async_std::test]
-async fn test_notification_and_subscribe() {
-    let target_data = String::from("Hello World!");
-    let upclient = UPClientZenoh::new(Config::default()).await.unwrap();
-    let uuri = create_utransport_uuri(1);
-
-    // Register the listener
-    let uuri_cloned = uuri.clone();
-    let data_cloned = target_data.clone();
-    let listener = move |result: Result<UMessage, UStatus>| match result {
-        Ok(msg) => {
-            if let Data::Value(v) = msg.payload.unwrap().data.unwrap() {
-                let value = v.into_iter().map(|c| c as char).collect::<String>();
-                assert_eq!(msg.attributes.unwrap().sink.unwrap(), uuri_cloned);
-                assert_eq!(value, data_cloned);
-            } else {
-                panic!("The message should be Data::Value type.");
-            }
-        }
-        Err(ustatus) => panic!("Internal Error: {ustatus:?}"),
-    };
-    let listener_string = upclient
-        .register_listener(uuri.clone(), Box::new(listener))
-        .await
-        .unwrap();
-
-    let umessage = UMessageBuilder::notification(&uuri)
-        .build_with_payload(
-            &UUIDBuilder::new(),
-            target_data.as_bytes().to_vec().into(),
-            UPayloadFormat::UPAYLOAD_FORMAT_TEXT,
-        )
-        .unwrap();
-    upclient.send(umessage).await.unwrap();
-
-    // Waiting for the subscriber to receive data
-    task::sleep(time::Duration::from_millis(1000)).await;
-
-    // Cleanup
-    upclient
-        .unregister_listener(uuri.clone(), &listener_string)
-        .await
-        .unwrap();
-}
-
-#[async_std::test]
-async fn test_rpc_server_client() {
-    let upclient_client = UPClientZenoh::new(Config::default()).await.unwrap();
-    let upclient_server = Arc::new(UPClientZenoh::new(Config::default()).await.unwrap());
-    let request_data = String::from("This is the request data");
-    let response_data = String::from("This is the response data");
-    let uuri = create_rpcserver_uuri();
-
-    // setup RpcServer callback
-    let upclient_server_cloned = upclient_server.clone();
-    let response_data_cloned = response_data.clone();
-    let request_data_cloned = request_data.clone();
-    let callback = move |result: Result<UMessage, UStatus>| {
-        match result {
-            Ok(msg) => {
-                let UMessage {
-                    attributes,
-                    payload,
-                    ..
-                } = msg;
-                // Get the UUri
-                let source = attributes.clone().unwrap().source.unwrap();
-                let sink = attributes.clone().unwrap().sink.unwrap();
-                // Build the payload to send back
-                if let Data::Value(v) = payload.unwrap().data.unwrap() {
-                    let value = v.into_iter().map(|c| c as char).collect::<String>();
-                    assert_eq!(request_data_cloned, value);
-                } else {
-                    panic!("The message should be Data::Value type.");
-                }
-                let upayload = UPayload {
-                    length: Some(0),
-                    format: UPayloadFormat::UPAYLOAD_FORMAT_TEXT.into(),
-                    data: Some(Data::Value(response_data_cloned.as_bytes().to_vec())),
-                    ..Default::default()
-                };
-                // Set the attributes type to Response
-                let mut uattributes = attributes.unwrap();
-                uattributes.type_ = UMessageType::UMESSAGE_TYPE_RESPONSE.into();
-                uattributes.sink = Some(source.clone()).into();
-                uattributes.source = Some(sink.clone()).into();
-                // Send back result
-                block_on(upclient_server_cloned.send(UMessage {
-                    attributes: Some(uattributes).into(),
-                    payload: Some(upayload).into(),
-                    ..Default::default()
-                }))
-                .unwrap();
-            }
-            Err(ustatus) => {
-                panic!("Internal Error: {ustatus:?}");
-            }
-        }
-    };
-    upclient_server
-        .register_rpc_listener(uuri.clone(), Box::new(callback))
-        .await
-        .unwrap();
-    // Need some time for queryable to run
-    task::sleep(time::Duration::from_millis(1000)).await;
-
-    // Run RpcClient
-    let payload = UPayload {
-        length: Some(0),
-        format: UPayloadFormat::UPAYLOAD_FORMAT_TEXT.into(),
-        data: Some(Data::Value(request_data.as_bytes().to_vec())),
-        ..Default::default()
-    };
-    let result = upclient_client
-        .invoke_method(uuri, payload, CallOptionsBuilder::default().build())
-        .await;
-
-    // Process the result
-    if let Data::Value(v) = result.unwrap().payload.unwrap().data.unwrap() {
-        let value = v.into_iter().map(|c| c as char).collect::<String>();
-        assert_eq!(response_data, value);
-    } else {
-        panic!("Failed to get result from invoke_method.");
-    }
-}
-
-#[async_std::test]
-async fn test_register_listener_with_special_uuri() {
-    let upclient1 = Arc::new(UPClientZenoh::new(Config::default()).await.unwrap());
-    let upclient1_clone = upclient1.clone();
-    let upclient2 = UPClientZenoh::new(Config::default()).await.unwrap();
-    // Create data
-    let publish_data = String::from("Hello World!");
-    let publish_data_clone = publish_data.clone();
-    let request_data = String::from("This is the request data");
-    let request_data_clone = request_data.clone();
-
-    // Register the listener
-    let listener_uuri = create_special_uuri();
-    let listener = move |result: Result<UMessage, UStatus>| match result {
-        Ok(msg) => {
-            let UMessage {
-                attributes,
-                payload,
-                ..
-            } = msg;
-            let value = if let Data::Value(v) = payload.clone().unwrap().data.unwrap() {
-                v.into_iter().map(|c| c as char).collect::<String>()
-            } else {
-                panic!("The message should be Data::Value type.");
-            };
-            match attributes.type_.enum_value().unwrap() {
-                UMessageType::UMESSAGE_TYPE_PUBLISH => {
-                    assert_eq!(publish_data_clone, value);
-                }
-                UMessageType::UMESSAGE_TYPE_REQUEST => {
-                    assert_eq!(request_data_clone, value);
-                    // Set the attributes type to Response
-                    let mut uattributes = attributes.unwrap();
-                    uattributes.type_ = UMessageType::UMESSAGE_TYPE_RESPONSE.into();
-                    // Swap source and sink
-                    (uattributes.sink, uattributes.source) =
-                        (uattributes.source.clone(), uattributes.sink.clone());
-                    // Send back result
-                    block_on(upclient1_clone.send(UMessage {
-                        attributes: Some(uattributes).into(),
-                        payload,
-                        ..Default::default()
-                    }))
-                    .unwrap();
-                }
-                UMessageType::UMESSAGE_TYPE_RESPONSE => {
-                    panic!("Response type");
-                }
-                UMessageType::UMESSAGE_TYPE_UNSPECIFIED => {
-                    panic!("Unknown type");
-                }
-            }
-        }
-        Err(ustatus) => panic!("Internal Error: {ustatus:?}"),
-    };
-    let listener_string = upclient1
-        .register_listener(listener_uuri.clone(), Box::new(listener))
-        .await
-        .unwrap();
-
-    // send Publish
-    {
-        let mut publish_uuri = create_utransport_uuri(0);
-        publish_uuri.authority = Some(create_authority()).into();
-
-        let umessage = UMessageBuilder::publish(&publish_uuri)
-            .build_with_payload(
-                &UUIDBuilder::new(),
-                publish_data.as_bytes().to_vec().into(),
-                UPayloadFormat::UPAYLOAD_FORMAT_TEXT,
-            )
-            .unwrap();
-        upclient2.send(umessage).await.unwrap();
-
-        // Waiting for the subscriber to receive data
-        task::sleep(time::Duration::from_millis(1000)).await;
-    }
-    // send Request
-    {
-        let mut request_uuri = create_rpcserver_uuri();
-        request_uuri.authority = Some(create_authority()).into();
-
-        // Run RpcClient
-        let payload = UPayload {
-            length: Some(0),
-            format: UPayloadFormat::UPAYLOAD_FORMAT_TEXT.into(),
-            data: Some(Data::Value(request_data.as_bytes().to_vec())),
-            ..Default::default()
-        };
-        let result = upclient2
-            .invoke_method(request_uuri, payload, CallOptionsBuilder::default().build())
-            .await;
-        // Process the result
-        if let Data::Value(v) = result.unwrap().payload.unwrap().data.unwrap() {
-            let value = v.into_iter().map(|c| c as char).collect::<String>();
-            assert_eq!(request_data, value);
-        } else {
-            panic!("Failed to get result from invoke_method.");
-        }
-    }
-
-    // Cleanup
-    upclient1
-        .unregister_listener(listener_uuri, &listener_string)
-        .await
-        .unwrap();
-}
+// #[async_std::test]
+// async fn test_rpcserver_register_and_unregister() {
+//     let upclient = UPClientZenoh::new(Config::default()).await.unwrap();
+//     let uuri = create_rpcserver_uuri();
+//
+//     // Compare the return string
+//     let listener_string = upclient
+//         .register_rpc_listener(uuri.clone(), Box::new(|_| {}))
+//         .await
+//         .unwrap();
+//     assert_eq!(listener_string, "upl/0100162e04d20100_0");
+//
+//     // Able to ungister
+//     upclient
+//         .unregister_rpc_listener(uuri.clone(), &listener_string)
+//         .await
+//         .unwrap();
+//
+//     // Unable to ungister
+//     let result = upclient
+//         .unregister_rpc_listener(uuri.clone(), &listener_string)
+//         .await;
+//     assert_eq!(
+//         result,
+//         Err(UStatus::fail_with_code(
+//             UCode::INVALID_ARGUMENT,
+//             "RPC request listener doesn't exist"
+//         ))
+//     );
+// }
+//
+// #[async_std::test]
+// async fn test_utransport_special_uuri_register_and_unregister() {
+//     let upclient = UPClientZenoh::new(Config::default()).await.unwrap();
+//     let uuri = create_special_uuri();
+//
+//     // Compare the return string
+//     let listener_string = upclient
+//         .register_listener(uuri.clone(), Box::new(|_| {}))
+//         .await
+//         .unwrap();
+//     assert_eq!(
+//         listener_string,
+//         "upr/060102030a0b0c/**_0&upr/060102030a0b0c/**_1&upr/060102030a0b0c/**_2"
+//     );
+//
+//     // Able to ungister
+//     upclient
+//         .unregister_listener(uuri.clone(), &listener_string)
+//         .await
+//         .unwrap();
+//
+//     // Unable to ungister
+//     let result = upclient
+//         .unregister_listener(uuri.clone(), &listener_string)
+//         .await;
+//     assert_eq!(
+//         result,
+//         Err(UStatus::fail_with_code(
+//             UCode::INVALID_ARGUMENT,
+//             "RPC response callback doesn't exist"
+//         ))
+//     );
+// }
+//
+// #[async_std::test]
+// async fn test_publish_and_subscribe() {
+//     let target_data = String::from("Hello World!");
+//     let upclient = UPClientZenoh::new(Config::default()).await.unwrap();
+//     let uuri = create_utransport_uuri(0);
+//
+//     // Register the listener
+//     let uuri_cloned = uuri.clone();
+//     let data_cloned = target_data.clone();
+//     let listener = move |result: Result<UMessage, UStatus>| match result {
+//         Ok(msg) => {
+//             if let Data::Value(v) = msg.payload.unwrap().data.unwrap() {
+//                 let value = v.into_iter().map(|c| c as char).collect::<String>();
+//                 assert_eq!(msg.attributes.unwrap().source.unwrap(), uuri_cloned);
+//                 assert_eq!(value, data_cloned);
+//             } else {
+//                 panic!("The message should be Data::Value type.");
+//             }
+//         }
+//         Err(ustatus) => panic!("Internal Error: {ustatus:?}"),
+//     };
+//     let listener_string = upclient
+//         .register_listener(uuri.clone(), Box::new(listener))
+//         .await
+//         .unwrap();
+//
+//     let umessage = UMessageBuilder::publish(&uuri)
+//         .build_with_payload(
+//             &UUIDBuilder::new(),
+//             target_data.as_bytes().to_vec().into(),
+//             UPayloadFormat::UPAYLOAD_FORMAT_TEXT,
+//         )
+//         .unwrap();
+//     upclient.send(umessage).await.unwrap();
+//
+//     // Waiting for the subscriber to receive data
+//     task::sleep(time::Duration::from_millis(1000)).await;
+//
+//     // Cleanup
+//     upclient
+//         .unregister_listener(uuri.clone(), &listener_string)
+//         .await
+//         .unwrap();
+// }
+//
+// #[async_std::test]
+// async fn test_notification_and_subscribe() {
+//     let target_data = String::from("Hello World!");
+//     let upclient = UPClientZenoh::new(Config::default()).await.unwrap();
+//     let uuri = create_utransport_uuri(1);
+//
+//     // Register the listener
+//     let uuri_cloned = uuri.clone();
+//     let data_cloned = target_data.clone();
+//     let listener = move |result: Result<UMessage, UStatus>| match result {
+//         Ok(msg) => {
+//             if let Data::Value(v) = msg.payload.unwrap().data.unwrap() {
+//                 let value = v.into_iter().map(|c| c as char).collect::<String>();
+//                 assert_eq!(msg.attributes.unwrap().sink.unwrap(), uuri_cloned);
+//                 assert_eq!(value, data_cloned);
+//             } else {
+//                 panic!("The message should be Data::Value type.");
+//             }
+//         }
+//         Err(ustatus) => panic!("Internal Error: {ustatus:?}"),
+//     };
+//     let listener_string = upclient
+//         .register_listener(uuri.clone(), Box::new(listener))
+//         .await
+//         .unwrap();
+//
+//     let umessage = UMessageBuilder::notification(&uuri)
+//         .build_with_payload(
+//             &UUIDBuilder::new(),
+//             target_data.as_bytes().to_vec().into(),
+//             UPayloadFormat::UPAYLOAD_FORMAT_TEXT,
+//         )
+//         .unwrap();
+//     upclient.send(umessage).await.unwrap();
+//
+//     // Waiting for the subscriber to receive data
+//     task::sleep(time::Duration::from_millis(1000)).await;
+//
+//     // Cleanup
+//     upclient
+//         .unregister_listener(uuri.clone(), &listener_string)
+//         .await
+//         .unwrap();
+// }
+//
+// #[async_std::test]
+// async fn test_rpc_server_client() {
+//     let upclient_client = UPClientZenoh::new(Config::default()).await.unwrap();
+//     let upclient_server = Arc::new(UPClientZenoh::new(Config::default()).await.unwrap());
+//     let request_data = String::from("This is the request data");
+//     let response_data = String::from("This is the response data");
+//     let uuri = create_rpcserver_uuri();
+//
+//     // setup RpcServer callback
+//     let upclient_server_cloned = upclient_server.clone();
+//     let response_data_cloned = response_data.clone();
+//     let request_data_cloned = request_data.clone();
+//     let callback = move |result: Result<UMessage, UStatus>| {
+//         match result {
+//             Ok(msg) => {
+//                 let UMessage {
+//                     attributes,
+//                     payload,
+//                     ..
+//                 } = msg;
+//                 // Get the UUri
+//                 let source = attributes.clone().unwrap().source.unwrap();
+//                 let sink = attributes.clone().unwrap().sink.unwrap();
+//                 // Build the payload to send back
+//                 if let Data::Value(v) = payload.unwrap().data.unwrap() {
+//                     let value = v.into_iter().map(|c| c as char).collect::<String>();
+//                     assert_eq!(request_data_cloned, value);
+//                 } else {
+//                     panic!("The message should be Data::Value type.");
+//                 }
+//                 let upayload = UPayload {
+//                     length: Some(0),
+//                     format: UPayloadFormat::UPAYLOAD_FORMAT_TEXT.into(),
+//                     data: Some(Data::Value(response_data_cloned.as_bytes().to_vec())),
+//                     ..Default::default()
+//                 };
+//                 // Set the attributes type to Response
+//                 let mut uattributes = attributes.unwrap();
+//                 uattributes.type_ = UMessageType::UMESSAGE_TYPE_RESPONSE.into();
+//                 uattributes.sink = Some(source.clone()).into();
+//                 uattributes.source = Some(sink.clone()).into();
+//                 // Send back result
+//                 block_on(upclient_server_cloned.send(UMessage {
+//                     attributes: Some(uattributes).into(),
+//                     payload: Some(upayload).into(),
+//                     ..Default::default()
+//                 }))
+//                 .unwrap();
+//             }
+//             Err(ustatus) => {
+//                 panic!("Internal Error: {ustatus:?}");
+//             }
+//         }
+//     };
+//     upclient_server
+//         .register_rpc_listener(uuri.clone(), Box::new(callback))
+//         .await
+//         .unwrap();
+//     // Need some time for queryable to run
+//     task::sleep(time::Duration::from_millis(1000)).await;
+//
+//     // Run RpcClient
+//     let payload = UPayload {
+//         length: Some(0),
+//         format: UPayloadFormat::UPAYLOAD_FORMAT_TEXT.into(),
+//         data: Some(Data::Value(request_data.as_bytes().to_vec())),
+//         ..Default::default()
+//     };
+//     let result = upclient_client
+//         .invoke_method(uuri, payload, CallOptionsBuilder::default().build())
+//         .await;
+//
+//     // Process the result
+//     if let Data::Value(v) = result.unwrap().payload.unwrap().data.unwrap() {
+//         let value = v.into_iter().map(|c| c as char).collect::<String>();
+//         assert_eq!(response_data, value);
+//     } else {
+//         panic!("Failed to get result from invoke_method.");
+//     }
+// }
+//
+// #[async_std::test]
+// async fn test_register_listener_with_special_uuri() {
+//     let upclient1 = Arc::new(UPClientZenoh::new(Config::default()).await.unwrap());
+//     let upclient1_clone = upclient1.clone();
+//     let upclient2 = UPClientZenoh::new(Config::default()).await.unwrap();
+//     // Create data
+//     let publish_data = String::from("Hello World!");
+//     let publish_data_clone = publish_data.clone();
+//     let request_data = String::from("This is the request data");
+//     let request_data_clone = request_data.clone();
+//
+//     // Register the listener
+//     let listener_uuri = create_special_uuri();
+//     let listener = move |result: Result<UMessage, UStatus>| match result {
+//         Ok(msg) => {
+//             let UMessage {
+//                 attributes,
+//                 payload,
+//                 ..
+//             } = msg;
+//             let value = if let Data::Value(v) = payload.clone().unwrap().data.unwrap() {
+//                 v.into_iter().map(|c| c as char).collect::<String>()
+//             } else {
+//                 panic!("The message should be Data::Value type.");
+//             };
+//             match attributes.type_.enum_value().unwrap() {
+//                 UMessageType::UMESSAGE_TYPE_PUBLISH => {
+//                     assert_eq!(publish_data_clone, value);
+//                 }
+//                 UMessageType::UMESSAGE_TYPE_REQUEST => {
+//                     assert_eq!(request_data_clone, value);
+//                     // Set the attributes type to Response
+//                     let mut uattributes = attributes.unwrap();
+//                     uattributes.type_ = UMessageType::UMESSAGE_TYPE_RESPONSE.into();
+//                     // Swap source and sink
+//                     (uattributes.sink, uattributes.source) =
+//                         (uattributes.source.clone(), uattributes.sink.clone());
+//                     // Send back result
+//                     block_on(upclient1_clone.send(UMessage {
+//                         attributes: Some(uattributes).into(),
+//                         payload,
+//                         ..Default::default()
+//                     }))
+//                     .unwrap();
+//                 }
+//                 UMessageType::UMESSAGE_TYPE_RESPONSE => {
+//                     panic!("Response type");
+//                 }
+//                 UMessageType::UMESSAGE_TYPE_UNSPECIFIED => {
+//                     panic!("Unknown type");
+//                 }
+//             }
+//         }
+//         Err(ustatus) => panic!("Internal Error: {ustatus:?}"),
+//     };
+//     let listener_string = upclient1
+//         .register_listener(listener_uuri.clone(), Box::new(listener))
+//         .await
+//         .unwrap();
+//
+//     // send Publish
+//     {
+//         let mut publish_uuri = create_utransport_uuri(0);
+//         publish_uuri.authority = Some(create_authority()).into();
+//
+//         let umessage = UMessageBuilder::publish(&publish_uuri)
+//             .build_with_payload(
+//                 &UUIDBuilder::new(),
+//                 publish_data.as_bytes().to_vec().into(),
+//                 UPayloadFormat::UPAYLOAD_FORMAT_TEXT,
+//             )
+//             .unwrap();
+//         upclient2.send(umessage).await.unwrap();
+//
+//         // Waiting for the subscriber to receive data
+//         task::sleep(time::Duration::from_millis(1000)).await;
+//     }
+//     // send Request
+//     {
+//         let mut request_uuri = create_rpcserver_uuri();
+//         request_uuri.authority = Some(create_authority()).into();
+//
+//         // Run RpcClient
+//         let payload = UPayload {
+//             length: Some(0),
+//             format: UPayloadFormat::UPAYLOAD_FORMAT_TEXT.into(),
+//             data: Some(Data::Value(request_data.as_bytes().to_vec())),
+//             ..Default::default()
+//         };
+//         let result = upclient2
+//             .invoke_method(request_uuri, payload, CallOptionsBuilder::default().build())
+//             .await;
+//         // Process the result
+//         if let Data::Value(v) = result.unwrap().payload.unwrap().data.unwrap() {
+//             let value = v.into_iter().map(|c| c as char).collect::<String>();
+//             assert_eq!(request_data, value);
+//         } else {
+//             panic!("Failed to get result from invoke_method.");
+//         }
+//     }
+//
+//     // Cleanup
+//     upclient1
+//         .unregister_listener(listener_uuri, &listener_string)
+//         .await
+//         .unwrap();
+// }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -169,41 +169,39 @@ async fn test_utransport_register_and_unregister() {
 //         ))
 //     );
 // }
-//
-// #[async_std::test]
-// async fn test_utransport_special_uuri_register_and_unregister() {
-//     let upclient = UPClientZenoh::new(Config::default()).await.unwrap();
-//     let uuri = create_special_uuri();
-//
-//     // Compare the return string
-//     let listener_string = upclient
-//         .register_listener(uuri.clone(), Box::new(|_| {}))
-//         .await
-//         .unwrap();
-//     assert_eq!(
-//         listener_string,
-//         "upr/060102030a0b0c/**_0&upr/060102030a0b0c/**_1&upr/060102030a0b0c/**_2"
-//     );
-//
-//     // Able to ungister
-//     upclient
-//         .unregister_listener(uuri.clone(), &listener_string)
-//         .await
-//         .unwrap();
-//
-//     // Unable to ungister
-//     let result = upclient
-//         .unregister_listener(uuri.clone(), &listener_string)
-//         .await;
-//     assert_eq!(
-//         result,
-//         Err(UStatus::fail_with_code(
-//             UCode::INVALID_ARGUMENT,
-//             "RPC response callback doesn't exist"
-//         ))
-//     );
-// }
-//
+
+#[async_std::test]
+async fn test_utransport_special_uuri_register_and_unregister() {
+    let upclient = UPClientZenoh::new(Config::default()).await.unwrap();
+    let uuri = create_special_uuri();
+
+    let foo_listener_register = FooListener;
+    let register_res = upclient
+        .register_listener(uuri.clone(), foo_listener_register)
+        .await;
+    assert_eq!(register_res, Ok(()));
+
+    let foo_listener_unregister = FooListener;
+    // Able to unregister
+    let unregister_res = upclient
+        .unregister_listener(uuri.clone(), foo_listener_unregister)
+        .await;
+    assert_eq!(unregister_res, Ok(()));
+
+    let foo_listener_unregister = FooListener;
+    // Unable to unregister
+    let result = upclient
+        .unregister_listener(uuri.clone(), foo_listener_unregister)
+        .await;
+    assert_eq!(
+        result,
+        Err(UStatus::fail_with_code(
+            UCode::NOT_FOUND,
+            format!("No listeners registered for topic: {:?}", &uuri),
+        ))
+    );
+}
+
 // #[async_std::test]
 // async fn test_publish_and_subscribe() {
 //     let target_data = String::from("Hello World!");


### PR DESCRIPTION
Hey @evshary :wave: 

This is definitely a WIP, but I will finish it.

I strongly want to test out the change I made to `up-rust` to align closer to the spec for uP-L1, which includes the `UListener` interface.

So far, so good with the parts I have modified and tested thus far:
* UTransport
* tests for UTransport

Still remaining to do:
- [ ] update rpc.rs
- [ ] update rpc tests
- [ ] get all integration tests working again
- [ ] point Cargo.toml for `up-rust` back to main repo if we think the approach taken in that PR is reasonable

Hope you don't feel I'm overstepping here, but I needed a way to verify that what I've done in `up-rust` will work in general for `up-client-foo-rust` implementations.

And hey -- as a side benefit `up-client-zenoh-rust` would be updated to agree with the latest in the `up-rust` repo :slightly_smiling_face: 