### PR TITLE
Use `up-rust` with `UListener` trait (where we care about the specific instance)

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Run tests and report code coverage
         run: |
           # enable nightly features so that we can also include Doctests
-          RUSTC_BOOTSTRAP=1 cargo tarpaulin -o xml -o lcov -o html --doc --tests
+          RUST_TEST_THREADS=1  RUSTC_BOOTSTRAP=1 cargo tarpaulin -o xml -o lcov -o html --doc --tests
 
       - name: Upload coverage report (xml)
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target
 
 # Ignore Cargo.lock while building libraries
 Cargo.lock
+
+.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,8 @@ log = "0.4.17"
 prost = "0.12"
 prost-types = "0.12"
 protobuf = { version = "3.3" }
-up-rust = { git = "https://github.com/eclipse-uprotocol/up-rust", rev = "68c8a1d94f0006daf4ba135c9cbbfddcd793108d" }
+# upstream
+# up-rust = { git = "https://github.com/eclipse-uprotocol/up-rust", rev = "68c8a1d94f0006daf4ba135c9cbbfddcd793108d" }
+# feature/ulistener_generics
+up-rust = { git = "https://github.com/PLeVasseur/uprotocol-rust_fork", branch = "feature/ulistener_instance_specific" }
 zenoh = { version = "0.10.1-rc", features = ["unstable"]}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ use std::{
     collections::HashMap,
     sync::{Arc, Mutex},
 };
-use up_rust::listener_wrapper::ListenerWrapper;
+use up_rust::ComparableListener;
 use up_rust::{
     UAttributes, UAuthority, UCode, UEntity, UPayloadFormat, UPriority, UStatus, UUIDBuilder, UUri,
 };
@@ -35,9 +35,9 @@ use zenoh::{
 const UATTRIBUTE_VERSION: u8 = 1;
 
 pub struct ZenohListener {}
-type SubscriberMap = Arc<Mutex<HashMap<(UUri, ListenerWrapper), Subscriber<'static, ()>>>>;
-type QueryableMap = Arc<Mutex<HashMap<(UUri, ListenerWrapper), Queryable<'static, ()>>>>;
-type RpcCallbackMap = Arc<Mutex<HashMap<UUri, HashSet<Arc<ListenerWrapper>>>>>;
+type SubscriberMap = Arc<Mutex<HashMap<(UUri, ComparableListener), Subscriber<'static, ()>>>>;
+type QueryableMap = Arc<Mutex<HashMap<(UUri, ComparableListener), Queryable<'static, ()>>>>;
+type RpcCallbackMap = Arc<Mutex<HashMap<UUri, HashSet<Arc<ComparableListener>>>>>;
 pub struct UPClientZenoh {
     session: Arc<Session>,
     // Able to unregister Subscriber

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,12 +35,8 @@ use zenoh::{
 const UATTRIBUTE_VERSION: u8 = 1;
 
 pub struct ZenohListener {}
-// We use HashMap<Arc<ListenerWrapper>, ...> and HashSet<Arc<ListenerWrapper>> because this is a
-// safer abstraction to use rather than a hash of UUri and ListenerWrapper
-type SubscriberMap =
-    Arc<Mutex<HashMap<UUri, HashMap<Arc<ListenerWrapper>, Subscriber<'static, ()>>>>>;
-type QueryableMap =
-    Arc<Mutex<HashMap<UUri, HashMap<Arc<ListenerWrapper>, Queryable<'static, ()>>>>>;
+type SubscriberMap = Arc<Mutex<HashMap<(UUri, ListenerWrapper), Subscriber<'static, ()>>>>;
+type QueryableMap = Arc<Mutex<HashMap<(UUri, ListenerWrapper), Queryable<'static, ()>>>>;
 type RpcCallbackMap = Arc<Mutex<HashMap<UUri, HashSet<Arc<ListenerWrapper>>>>>;
 pub struct UPClientZenoh {
     session: Arc<Session>,

--- a/src/utransport.rs
+++ b/src/utransport.rs
@@ -342,9 +342,8 @@ impl UPClientZenoh {
             .res()
             .await
         {
-            let mut subscriber_map_guard = self.subscriber_map.lock().unwrap();
-            let listeners = subscriber_map_guard.entry(topic.clone()).or_default();
-            listeners.insert(Arc::new(listener_wrapper), subscriber);
+            let mut subscribers = self.subscriber_map.lock().unwrap();
+            subscribers.insert((topic.clone(), listener_wrapper), subscriber);
         } else {
             return Err(UStatus::fail_with_code(
                 UCode::INTERNAL,
@@ -430,9 +429,8 @@ impl UPClientZenoh {
             .res()
             .await
         {
-            let mut queryable_map_guard = self.queryable_map.lock().unwrap();
-            let listeners = queryable_map_guard.entry(topic.clone()).or_default();
-            listeners.insert(Arc::new(listener_wrapper), queryable);
+            let mut queryables = self.queryable_map.lock().unwrap();
+            queryables.insert((topic.clone(), listener_wrapper), queryable);
         } else {
             return Err(UStatus::fail_with_code(
                 UCode::INTERNAL,
@@ -469,10 +467,8 @@ impl UPClientZenoh {
         listener: &ListenerWrapper,
     ) -> Result<(), UStatus> {
         let mut subscriber_map = self.subscriber_map.lock().unwrap();
-        if let Some(subscribers) = subscriber_map.get_mut(topic) {
-            if let Some(_subscriber) = subscribers.remove(listener) {
-                return Ok(());
-            }
+        if let Some(_subscriber) = subscriber_map.remove(&(topic.clone(), listener.clone())) {
+            return Ok(());
         }
         Err(UStatus::fail_with_code(
             UCode::NOT_FOUND,
@@ -486,10 +482,8 @@ impl UPClientZenoh {
         listener: &ListenerWrapper,
     ) -> Result<(), UStatus> {
         let mut queryable_map = self.queryable_map.lock().unwrap();
-        if let Some(queryables) = queryable_map.get_mut(topic) {
-            if let Some(_queryable) = queryables.remove(listener) {
-                return Ok(());
-            }
+        if let Some(_queryable) = queryable_map.remove(&(topic.clone(), listener.clone())) {
+            return Ok(());
         }
         Err(UStatus::fail_with_code(
             UCode::NOT_FOUND,

--- a/src/utransport.rs
+++ b/src/utransport.rs
@@ -20,6 +20,7 @@ use up_rust::{
     Data, UAttributes, UAttributesValidators, UCode, UMessage, UMessageType, UPayload,
     UPayloadFormat, UStatus, UTransport, UUri, UriValidator,
 };
+use zenoh::sample::Attachment;
 use zenoh::{
     prelude::{r#async::*, Sample},
     query::Reply,
@@ -27,6 +28,80 @@ use zenoh::{
 };
 
 impl UPClientZenoh {
+    async fn send_and_process_response_callbacks(
+        &self,
+        zenoh_key: &str,
+        value: Value,
+        attachment: Attachment,
+        listener: Arc<ListenerWrapper>,
+    ) -> Result<(), UStatus> {
+        let zenoh_callback = move |reply: Reply| {
+            let msg = match reply.sample {
+                Ok(sample) => {
+                    let Some(encoding) = UPClientZenoh::to_upayload_format(&sample.encoding) else {
+                        listener.on_receive(Err(UStatus::fail_with_code(
+                            UCode::INTERNAL,
+                            "Unable to get the encoding",
+                        )));
+                        return;
+                    };
+                    // TODO: Get the attributes
+                    // Create UAttribute
+                    let Some(attachment) = sample.attachment() else {
+                        listener.on_receive(Err(UStatus::fail_with_code(
+                            UCode::INTERNAL,
+                            "Unable to get attachment",
+                        )));
+                        return;
+                    };
+                    let u_attribute = match UPClientZenoh::attachment_to_uattributes(attachment) {
+                        Ok(uattr) => uattr,
+                        Err(e) => {
+                            log::error!("attachment_to_uattributes error: {:?}", e);
+                            listener.on_receive(Err(UStatus::fail_with_code(
+                                UCode::INTERNAL,
+                                "Unable to decode attribute",
+                            )));
+                            return;
+                        }
+                    };
+                    Ok(UMessage {
+                        attributes: Some(u_attribute).into(),
+                        payload: Some(UPayload {
+                            length: Some(0),
+                            format: encoding.into(),
+                            data: Some(Data::Value(sample.payload.contiguous().to_vec())),
+                            ..Default::default()
+                        })
+                        .into(),
+                        ..Default::default()
+                    })
+                }
+                Err(e) => Err(UStatus::fail_with_code(
+                    UCode::INTERNAL,
+                    format!("Error while parsing Zenoh reply: {e:?}"),
+                )),
+            };
+            listener.on_receive(msg);
+        };
+
+        // TODO: Adjust the timeout
+        let getbuilder = self
+            .session
+            .get(zenoh_key)
+            .with_value(value.clone())
+            .with_attachment(attachment.clone())
+            .target(QueryTarget::BestMatching)
+            .timeout(Duration::from_millis(1000))
+            .callback(zenoh_callback);
+        getbuilder.res().await.map_err(|e| {
+            log::error!("Zenoh error: {e:?}");
+            UStatus::fail_with_code(UCode::INTERNAL, "Unable to send get with Zenoh")
+        })?;
+
+        Ok(())
+    }
+
     async fn send_publish(
         &self,
         zenoh_key: &str,
@@ -125,73 +200,13 @@ impl UPClientZenoh {
         }
 
         for listener in callbacks {
-            let zenoh_callback = move |reply: Reply| {
-                let msg = match reply.sample {
-                    Ok(sample) => {
-                        let Some(encoding) = UPClientZenoh::to_upayload_format(&sample.encoding)
-                        else {
-                            listener.on_receive(Err(UStatus::fail_with_code(
-                                UCode::INTERNAL,
-                                "Unable to get the encoding",
-                            )));
-                            return;
-                        };
-                        // Get UAttribute from the attachment
-                        let Some(attachment) = sample.attachment() else {
-                            listener.on_receive(Err(UStatus::fail_with_code(
-                                UCode::INTERNAL,
-                                "Unable to get attachment",
-                            )));
-                            return;
-                        };
-                        let u_attribute = match UPClientZenoh::attachment_to_uattributes(attachment)
-                        {
-                            Ok(uattr) => uattr,
-                            Err(e) => {
-                                log::error!("attachment_to_uattributes error: {:?}", e);
-                                listener.on_receive(Err(UStatus::fail_with_code(
-                                    UCode::INTERNAL,
-                                    "Unable to decode attribute",
-                                )));
-                                return;
-                            }
-                        };
-                        Ok(UMessage {
-                            attributes: Some(u_attribute).into(),
-                            payload: Some(UPayload {
-                                length: Some(0),
-                                format: encoding.into(),
-                                data: Some(Data::Value(sample.payload.contiguous().to_vec())),
-                                ..Default::default()
-                            })
-                            .into(),
-                            ..Default::default()
-                        })
-                    }
-                    Err(e) => Err(UStatus::fail_with_code(
-                        UCode::INTERNAL,
-                        format!("Error while parsing Zenoh reply: {e:?}"),
-                    )),
-                };
-                listener.on_receive(msg);
-            };
-
-
-            let getbuilder = self
-                .session
-                .get(zenoh_key)
-                .with_value(value.clone())
-                .with_attachment(attachment.clone())
-                .target(QueryTarget::BestMatching)
-                .timeout(Duration::from_millis(u64::from(
-                // TODO: Workaround since TTL will be u32 in the future.
-                attributes.ttl.unwrap_or(1000).unsigned_abs(),
-            )))
-                .callback(zenoh_callback);
-            getbuilder.res().await.map_err(|e| {
-                log::error!("Zenoh error: {e:?}");
-                UStatus::fail_with_code(UCode::INTERNAL, "Unable to send get with Zenoh")
-            })?;
+            self.send_and_process_response_callbacks(
+                zenoh_key,
+                value.clone(),
+                attachment.clone(),
+                listener.clone(),
+            )
+            .await?;
         }
 
         Ok(())

--- a/src/utransport.rs
+++ b/src/utransport.rs
@@ -452,7 +452,13 @@ impl UPClientZenoh {
 
         let listeners = rpc_callback_map_guard.entry(topic.clone()).or_default();
 
-        listeners.insert(Arc::new(listener_wrapper));
+        let newly_added = listeners.insert(Arc::new(listener_wrapper));
+        if !newly_added {
+            return Err(UStatus::fail_with_code(
+                UCode::ALREADY_EXISTS,
+                format!("Same listener already registered to topic: {topic:?}"),
+            ));
+        }
 
         Ok(())
     }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -14,15 +14,11 @@
 use async_std::task::{self, block_on};
 use std::{sync::Arc, time};
 use up_client_zenoh::UPClientZenoh;
+use up_rust::ulistener::UListener;
 use up_rust::{
-    rpc::{CallOptionsBuilder, RpcClient, RpcServer},
-    transport::{builder::UMessageBuilder, datamodel::UTransport},
-    uprotocol::{
-        uri::uauthority::Number, Data, UAuthority, UCode, UEntity, UMessage, UMessageType,
-        UPayload, UPayloadFormat, UResource, UStatus, UUri,
-    },
-    uri::builder::resourcebuilder::UResourceBuilder,
-    uuid::builder::UUIDBuilder,
+    CallOptionsBuilder, Data, Number, RpcClient, UAuthority, UCode, UEntity, UMessage,
+    UMessageBuilder, UMessageType, UPayload, UPayloadFormat, UResource, UResourceBuilder, UStatus,
+    UTransport, UUIDBuilder, UUri,
 };
 use zenoh::config::Config;
 
@@ -94,6 +90,16 @@ fn create_authority() -> UAuthority {
     }
 }
 
+fn create_entity() -> UEntity {
+    UEntity {
+        name: "UEntName".to_string(),
+        id: Some(111),
+        version_major: Some(1),
+        version_minor: None,
+        ..Default::default()
+    }
+}
+
 fn create_special_uuri() -> UUri {
     UUri {
         authority: Some(create_authority()).into(),
@@ -101,206 +107,277 @@ fn create_special_uuri() -> UUri {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+struct FooListener;
+
+impl UListener for FooListener {
+    fn on_receive(&self, received: Result<UMessage, UStatus>) {
+        println!("From within FooListener, received: {:?}", &received);
+    }
+}
+
 #[async_std::test]
 async fn test_utransport_register_and_unregister() {
-    let upclient = UPClientZenoh::new(Config::default()).await.unwrap();
+    let upclient = UPClientZenoh::new(Config::default(), create_authority(), create_entity())
+        .await
+        .unwrap();
     let uuri = create_utransport_uuri(0);
 
-    // Compare the return string
-    let listener_string = upclient
-        .register_listener(uuri.clone(), Box::new(|_| {}))
-        .await
-        .unwrap();
-    assert_eq!(listener_string, "upl/0100162e04d20100_0");
+    let foo_listener = Arc::new(FooListener);
+    // Able to register
+    let register_res = upclient
+        .register_listener(uuri.clone(), &foo_listener)
+        .await;
+    assert_eq!(register_res, Ok(()));
 
-    // Able to ungister
-    upclient
-        .unregister_listener(uuri.clone(), &listener_string)
-        .await
-        .unwrap();
+    // Able to unregister
+    let unregister_res = upclient
+        .unregister_listener(uuri.clone(), &foo_listener)
+        .await;
+    assert_eq!(unregister_res, Ok(()));
 
-    // Unable to ungister
+    // Unable to unregister
     let result = upclient
-        .unregister_listener(uuri.clone(), &listener_string)
+        .unregister_listener(uuri.clone(), &foo_listener)
         .await;
     assert_eq!(
         result,
         Err(UStatus::fail_with_code(
-            UCode::INVALID_ARGUMENT,
-            "Publish listener doesn't exist"
+            UCode::NOT_FOUND,
+            format!("No listeners registered for topic: {:?}", &uuri),
         ))
     );
 }
 
 #[async_std::test]
 async fn test_rpcserver_register_and_unregister() {
-    let upclient = UPClientZenoh::new(Config::default()).await.unwrap();
+    let upclient = UPClientZenoh::new(Config::default(), create_authority(), create_entity())
+        .await
+        .unwrap();
     let uuri = create_rpcserver_uuri();
 
-    // Compare the return string
-    let listener_string = upclient
-        .register_rpc_listener(uuri.clone(), Box::new(|_| {}))
-        .await
-        .unwrap();
-    assert_eq!(listener_string, "upl/0100162e04d20100_0");
-
-    // Able to ungister
-    upclient
-        .unregister_rpc_listener(uuri.clone(), &listener_string)
-        .await
-        .unwrap();
-
-    // Unable to ungister
-    let result = upclient
-        .unregister_rpc_listener(uuri.clone(), &listener_string)
+    let foo_listener = Arc::new(FooListener);
+    let register_res = upclient
+        .register_listener(uuri.clone(), &foo_listener)
         .await;
-    assert_eq!(
-        result,
-        Err(UStatus::fail_with_code(
-            UCode::INVALID_ARGUMENT,
-            "RPC request listener doesn't exist"
-        ))
-    );
+    assert_eq!(register_res, Ok(()));
+
+    // Able to unregister
+    let unregister_res = upclient
+        .unregister_listener(uuri.clone(), &foo_listener)
+        .await;
+    assert_eq!(unregister_res, Ok(()));
+
+    // Unable to unregister
+    let unregister_res = upclient
+        .unregister_listener(uuri.clone(), &foo_listener)
+        .await;
+    assert!(unregister_res.is_err());
 }
 
 #[async_std::test]
 async fn test_utransport_special_uuri_register_and_unregister() {
-    let upclient = UPClientZenoh::new(Config::default()).await.unwrap();
+    let upclient = UPClientZenoh::new(Config::default(), create_authority(), create_entity())
+        .await
+        .unwrap();
     let uuri = create_special_uuri();
 
-    // Compare the return string
-    let listener_string = upclient
-        .register_listener(uuri.clone(), Box::new(|_| {}))
-        .await
-        .unwrap();
-    assert_eq!(
-        listener_string,
-        "upr/060102030a0b0c/**_0&upr/060102030a0b0c/**_1&upr/060102030a0b0c/**_2"
-    );
+    let foo_listener = Arc::new(FooListener);
+    let register_res = upclient
+        .register_listener(uuri.clone(), &foo_listener)
+        .await;
+    assert_eq!(register_res, Ok(()));
 
-    // Able to ungister
-    upclient
-        .unregister_listener(uuri.clone(), &listener_string)
-        .await
-        .unwrap();
+    // Able to unregister
+    let unregister_res = upclient
+        .unregister_listener(uuri.clone(), &foo_listener)
+        .await;
+    assert_eq!(unregister_res, Ok(()));
 
-    // Unable to ungister
+    // Unable to unregister
     let result = upclient
-        .unregister_listener(uuri.clone(), &listener_string)
+        .unregister_listener(uuri.clone(), &foo_listener)
         .await;
     assert_eq!(
         result,
         Err(UStatus::fail_with_code(
-            UCode::INVALID_ARGUMENT,
-            "RPC response callback doesn't exist"
+            UCode::NOT_FOUND,
+            format!("No listeners registered for topic: {:?}", &uuri),
         ))
     );
+}
+
+#[derive(Debug, Clone)]
+struct PubSubTestListener {
+    expected_uuri: Arc<UUri>,
+    expected_data: Arc<String>,
+}
+
+impl PubSubTestListener {
+    pub fn new(uuri: UUri, data: String) -> Self {
+        Self {
+            expected_uuri: Arc::new(uuri),
+            expected_data: Arc::new(data),
+        }
+    }
+}
+
+impl UListener for PubSubTestListener {
+    fn on_receive(&self, received: Result<UMessage, UStatus>) {
+        match received {
+            Ok(msg) => {
+                if let Data::Value(v) = msg.payload.unwrap().data.unwrap() {
+                    let value = v.into_iter().map(|c| c as char).collect::<String>();
+                    assert_eq!(msg.attributes.unwrap().source.unwrap(), *self.expected_uuri);
+                    assert_eq!(value, *self.expected_data);
+                } else {
+                    panic!("The message should be Data::Value type.");
+                }
+            }
+            Err(ustatus) => panic!("Internal Error: {ustatus:?}"),
+        }
+    }
 }
 
 #[async_std::test]
 async fn test_publish_and_subscribe() {
     let target_data = String::from("Hello World!");
-    let upclient = UPClientZenoh::new(Config::default()).await.unwrap();
-    let uuri = create_utransport_uuri(0);
-
-    // Register the listener
-    let uuri_cloned = uuri.clone();
-    let data_cloned = target_data.clone();
-    let listener = move |result: Result<UMessage, UStatus>| match result {
-        Ok(msg) => {
-            if let Data::Value(v) = msg.payload.unwrap().data.unwrap() {
-                let value = v.into_iter().map(|c| c as char).collect::<String>();
-                assert_eq!(msg.attributes.unwrap().source.unwrap(), uuri_cloned);
-                assert_eq!(value, data_cloned);
-            } else {
-                panic!("The message should be Data::Value type.");
-            }
-        }
-        Err(ustatus) => panic!("Internal Error: {ustatus:?}"),
-    };
-    let listener_string = upclient
-        .register_listener(uuri.clone(), Box::new(listener))
+    let upclient = UPClientZenoh::new(Config::default(), create_authority(), create_entity())
         .await
         .unwrap();
+    let topic = create_utransport_uuri(0);
 
-    let umessage = UMessageBuilder::publish(&uuri)
+    // Register the listener
+    let pub_sub_test_listener =
+        Arc::new(PubSubTestListener::new(topic.clone(), target_data.clone()));
+    let register_res = upclient
+        .register_listener(topic.clone(), &pub_sub_test_listener)
+        .await;
+    assert_eq!(register_res, Ok(()));
+
+    let uuid_builder = UUIDBuilder::new();
+
+    let umessage = UMessageBuilder::publish(topic.clone())
+        .with_message_id(uuid_builder.build())
         .build_with_payload(
-            &UUIDBuilder::new(),
             target_data.as_bytes().to_vec().into(),
             UPayloadFormat::UPAYLOAD_FORMAT_TEXT,
         )
         .unwrap();
-    upclient.send(umessage).await.unwrap();
+    let send_res = upclient.send(umessage).await;
+    assert_eq!(send_res, Ok(()));
 
     // Waiting for the subscriber to receive data
     task::sleep(time::Duration::from_millis(1000)).await;
 
     // Cleanup
-    upclient
-        .unregister_listener(uuri.clone(), &listener_string)
-        .await
-        .unwrap();
+    let unregister_res = upclient
+        .unregister_listener(topic.clone(), &pub_sub_test_listener)
+        .await;
+    assert_eq!(unregister_res, Ok(()));
+}
+
+#[derive(Clone)]
+struct NotifTestListener {
+    expected_sink: Arc<UUri>,
+    expected_data: Arc<String>,
+}
+
+impl NotifTestListener {
+    pub fn new(expected_sink: UUri, expected_data: String) -> Self {
+        Self {
+            expected_sink: Arc::new(expected_sink),
+            expected_data: Arc::new(expected_data),
+        }
+    }
+}
+
+impl UListener for NotifTestListener {
+    fn on_receive(&self, received: Result<UMessage, UStatus>) {
+        match received {
+            Ok(msg) => {
+                if let Data::Value(v) = msg.payload.unwrap().data.unwrap() {
+                    let value = v.into_iter().map(|c| c as char).collect::<String>();
+                    assert_eq!(msg.attributes.unwrap().sink.unwrap(), *self.expected_sink);
+                    assert_eq!(value, *self.expected_data);
+                } else {
+                    panic!("The message should be Data::Value type.");
+                }
+            }
+            Err(ustatus) => panic!("Internal Error: {ustatus:?}"),
+        }
+    }
 }
 
 #[async_std::test]
 async fn test_notification_and_subscribe() {
     let target_data = String::from("Hello World!");
-    let upclient = UPClientZenoh::new(Config::default()).await.unwrap();
-    let uuri = create_utransport_uuri(1);
-
-    // Register the listener
-    let uuri_cloned = uuri.clone();
-    let data_cloned = target_data.clone();
-    let listener = move |result: Result<UMessage, UStatus>| match result {
-        Ok(msg) => {
-            if let Data::Value(v) = msg.payload.unwrap().data.unwrap() {
-                let value = v.into_iter().map(|c| c as char).collect::<String>();
-                assert_eq!(msg.attributes.unwrap().sink.unwrap(), uuri_cloned);
-                assert_eq!(value, data_cloned);
-            } else {
-                panic!("The message should be Data::Value type.");
-            }
-        }
-        Err(ustatus) => panic!("Internal Error: {ustatus:?}"),
-    };
-    let listener_string = upclient
-        .register_listener(uuri.clone(), Box::new(listener))
+    let upclient = UPClientZenoh::new(Config::default(), create_authority(), create_entity())
         .await
         .unwrap();
+    let origin_uuri = create_utransport_uuri(1);
+    let destination_uuri = create_utransport_uuri(2);
 
-    let umessage = UMessageBuilder::notification(&uuri)
+    // Register the listener
+    let test_correct_received_listener = Arc::new(NotifTestListener::new(
+        destination_uuri.clone(),
+        target_data.clone(),
+    ));
+
+    let register_res = upclient
+        .register_listener(destination_uuri.clone(), &test_correct_received_listener)
+        .await;
+    assert_eq!(register_res, Ok(()));
+
+    let uuid_builder = UUIDBuilder::new();
+
+    let umessage = UMessageBuilder::notification(origin_uuri.clone(), destination_uuri.clone())
+        .with_message_id(uuid_builder.build())
         .build_with_payload(
-            &UUIDBuilder::new(),
             target_data.as_bytes().to_vec().into(),
             UPayloadFormat::UPAYLOAD_FORMAT_TEXT,
         )
         .unwrap();
-    upclient.send(umessage).await.unwrap();
+    let send_res = upclient.send(umessage).await;
+    assert_eq!(send_res, Ok(()));
 
     // Waiting for the subscriber to receive data
     task::sleep(time::Duration::from_millis(1000)).await;
 
     // Cleanup
-    upclient
-        .unregister_listener(uuri.clone(), &listener_string)
-        .await
-        .unwrap();
+    let unregister_res = upclient
+        .unregister_listener(destination_uuri.clone(), &test_correct_received_listener)
+        .await;
+    assert_eq!(unregister_res, Ok(()));
 }
 
-#[async_std::test]
-async fn test_rpc_server_client() {
-    let upclient_client = UPClientZenoh::new(Config::default()).await.unwrap();
-    let upclient_server = Arc::new(UPClientZenoh::new(Config::default()).await.unwrap());
-    let request_data = String::from("This is the request data");
-    let response_data = String::from("This is the response data");
-    let uuri = create_rpcserver_uuri();
+#[derive(Clone)]
+struct RpcTestListener {
+    expected_request_data: Arc<String>,
+    response_data: Arc<String>,
+    upclient_server: Arc<UPClientZenoh>,
+}
 
-    // setup RpcServer callback
-    let upclient_server_cloned = upclient_server.clone();
-    let response_data_cloned = response_data.clone();
-    let request_data_cloned = request_data.clone();
-    let callback = move |result: Result<UMessage, UStatus>| {
-        match result {
+impl RpcTestListener {
+    pub fn new(
+        expected_request_data: &str,
+        response_data: &str,
+        upclient_server: &Arc<UPClientZenoh>,
+    ) -> Self {
+        let expected_request_data = Arc::new(expected_request_data.to_string());
+        let response_data = Arc::new(response_data.to_string());
+        let upclient_server = upclient_server.clone();
+        Self {
+            expected_request_data,
+            response_data,
+            upclient_server,
+        }
+    }
+}
+
+impl UListener for RpcTestListener {
+    fn on_receive(&self, received: Result<UMessage, UStatus>) {
+        match received {
             Ok(msg) => {
                 let UMessage {
                     attributes,
@@ -313,14 +390,14 @@ async fn test_rpc_server_client() {
                 // Build the payload to send back
                 if let Data::Value(v) = payload.unwrap().data.unwrap() {
                     let value = v.into_iter().map(|c| c as char).collect::<String>();
-                    assert_eq!(request_data_cloned, value);
+                    assert_eq!(*self.expected_request_data, value);
                 } else {
                     panic!("The message should be Data::Value type.");
                 }
                 let upayload = UPayload {
                     length: Some(0),
                     format: UPayloadFormat::UPAYLOAD_FORMAT_TEXT.into(),
-                    data: Some(Data::Value(response_data_cloned.as_bytes().to_vec())),
+                    data: Some(Data::Value(self.response_data.as_bytes().to_vec())),
                     ..Default::default()
                 };
                 // Set the attributes type to Response
@@ -328,21 +405,53 @@ async fn test_rpc_server_client() {
                 uattributes.type_ = UMessageType::UMESSAGE_TYPE_RESPONSE.into();
                 uattributes.sink = Some(source.clone()).into();
                 uattributes.source = Some(sink.clone()).into();
+                // move id to reqid and generate new id
+                let uuid_builder = UUIDBuilder::new();
+                let id = uuid_builder.build();
+                uattributes.reqid = uattributes.id;
+                uattributes.id = Some(id).into();
                 // Send back result
-                block_on(upclient_server_cloned.send(UMessage {
+                let send_res = block_on(self.upclient_server.send(UMessage {
                     attributes: Some(uattributes).into(),
                     payload: Some(upayload).into(),
                     ..Default::default()
-                }))
-                .unwrap();
+                }));
+                assert_eq!(send_res, Ok(()));
             }
             Err(ustatus) => {
                 panic!("Internal Error: {ustatus:?}");
             }
         }
-    };
+    }
+}
+
+#[async_std::test]
+async fn test_rpc_server_client() {
+    let upclient_client =
+        UPClientZenoh::new(Config::default(), create_authority(), create_entity())
+            .await
+            .unwrap();
+    let upclient_server = Arc::new(
+        UPClientZenoh::new(
+            Config::default(),
+            create_authority(),
+            create_rpcserver_uuri().entity.unwrap(),
+        )
+        .await
+        .unwrap(),
+    );
+    let request_data = String::from("This is the request data");
+    let response_data = String::from("This is the response data");
+    let uuri = create_rpcserver_uuri();
+
+    // setup RpcServer callback
+    let rpc_test_listener = Arc::new(RpcTestListener::new(
+        &request_data,
+        &response_data,
+        &upclient_server,
+    ));
     upclient_server
-        .register_rpc_listener(uuri.clone(), Box::new(callback))
+        .register_listener(uuri.clone(), &rpc_test_listener)
         .await
         .unwrap();
     // Need some time for queryable to run
@@ -368,82 +477,127 @@ async fn test_rpc_server_client() {
     }
 }
 
+struct TestAuthorityOnlyRegisterListener {
+    expected_publish_data: Arc<String>,
+    expected_request_data: Arc<String>,
+    service_provider_up_client: Arc<UPClientZenoh>,
+}
+
+impl TestAuthorityOnlyRegisterListener {
+    pub fn new(
+        expected_publish_data: &str,
+        expected_request_data: &str,
+        service_provider_up_client: &Arc<UPClientZenoh>,
+    ) -> Self {
+        let expected_publish_data = Arc::new(expected_publish_data.to_string());
+        let expected_request_data = Arc::new(expected_request_data.to_string());
+        let service_provider_up_client = service_provider_up_client.clone();
+        Self {
+            expected_publish_data,
+            expected_request_data,
+            service_provider_up_client,
+        }
+    }
+}
+
+impl UListener for TestAuthorityOnlyRegisterListener {
+    fn on_receive(&self, received: Result<UMessage, UStatus>) {
+        match received {
+            Ok(msg) => {
+                let UMessage {
+                    attributes,
+                    payload,
+                    ..
+                } = msg;
+                let value = if let Data::Value(v) = payload.clone().unwrap().data.unwrap() {
+                    v.into_iter().map(|c| c as char).collect::<String>()
+                } else {
+                    panic!("The message should be Data::Value type.");
+                };
+                match attributes.type_.enum_value().unwrap() {
+                    UMessageType::UMESSAGE_TYPE_PUBLISH => {
+                        assert_eq!(*self.expected_publish_data, value);
+                    }
+                    UMessageType::UMESSAGE_TYPE_REQUEST => {
+                        assert_eq!(*self.expected_request_data, value);
+                        // Set the attributes type to Response
+                        let mut uattributes = attributes.unwrap();
+                        uattributes.type_ = UMessageType::UMESSAGE_TYPE_RESPONSE.into();
+                        // Swap source and sink
+                        (uattributes.sink, uattributes.source) =
+                            (uattributes.source.clone(), uattributes.sink.clone());
+                        // move id to reqid and generate new id
+                        let uuid_builder = UUIDBuilder::new();
+                        let id = uuid_builder.build();
+                        uattributes.reqid = uattributes.id;
+                        uattributes.id = Some(id).into();
+                        // Send back result
+                        let send_res = block_on(self.service_provider_up_client.send(UMessage {
+                            attributes: Some(uattributes).into(),
+                            payload,
+                            ..Default::default()
+                        }));
+                        assert_eq!(send_res, Ok(()));
+                    }
+                    UMessageType::UMESSAGE_TYPE_RESPONSE => {
+                        panic!("Response type");
+                    }
+                    UMessageType::UMESSAGE_TYPE_UNSPECIFIED => {
+                        panic!("Unknown type");
+                    }
+                }
+            }
+            Err(ustatus) => panic!("Internal Error: {ustatus:?}"),
+        }
+    }
+}
+
 #[async_std::test]
 async fn test_register_listener_with_special_uuri() {
-    let upclient1 = Arc::new(UPClientZenoh::new(Config::default()).await.unwrap());
-    let upclient1_clone = upclient1.clone();
-    let upclient2 = UPClientZenoh::new(Config::default()).await.unwrap();
+    let upclient1 = Arc::new(
+        UPClientZenoh::new(Config::default(), create_authority(), create_entity())
+            .await
+            .unwrap(),
+    );
+    let upclient2 = UPClientZenoh::new(Config::default(), create_authority(), create_entity())
+        .await
+        .unwrap();
     // Create data
     let publish_data = String::from("Hello World!");
-    let publish_data_clone = publish_data.clone();
     let request_data = String::from("This is the request data");
-    let request_data_clone = request_data.clone();
 
     // Register the listener
     let listener_uuri = create_special_uuri();
-    let listener = move |result: Result<UMessage, UStatus>| match result {
-        Ok(msg) => {
-            let UMessage {
-                attributes,
-                payload,
-                ..
-            } = msg;
-            let value = if let Data::Value(v) = payload.clone().unwrap().data.unwrap() {
-                v.into_iter().map(|c| c as char).collect::<String>()
-            } else {
-                panic!("The message should be Data::Value type.");
-            };
-            match attributes.type_.enum_value().unwrap() {
-                UMessageType::UMESSAGE_TYPE_PUBLISH => {
-                    assert_eq!(publish_data_clone, value);
-                }
-                UMessageType::UMESSAGE_TYPE_REQUEST => {
-                    assert_eq!(request_data_clone, value);
-                    // Set the attributes type to Response
-                    let mut uattributes = attributes.unwrap();
-                    uattributes.type_ = UMessageType::UMESSAGE_TYPE_RESPONSE.into();
-                    // Swap source and sink
-                    (uattributes.sink, uattributes.source) =
-                        (uattributes.source.clone(), uattributes.sink.clone());
-                    // Send back result
-                    block_on(upclient1_clone.send(UMessage {
-                        attributes: Some(uattributes).into(),
-                        payload,
-                        ..Default::default()
-                    }))
-                    .unwrap();
-                }
-                UMessageType::UMESSAGE_TYPE_RESPONSE => {
-                    panic!("Response type");
-                }
-                UMessageType::UMESSAGE_TYPE_UNSPECIFIED => {
-                    panic!("Unknown type");
-                }
-            }
-        }
-        Err(ustatus) => panic!("Internal Error: {ustatus:?}"),
-    };
-    let listener_string = upclient1
-        .register_listener(listener_uuri.clone(), Box::new(listener))
-        .await
-        .unwrap();
+    let listener = Arc::new(TestAuthorityOnlyRegisterListener::new(
+        &publish_data,
+        &request_data,
+        &upclient1,
+    ));
+    let register_res = upclient1
+        .register_listener(listener_uuri.clone(), &listener)
+        .await;
+    assert_eq!(register_res, Ok(()));
+
+    task::sleep(time::Duration::from_millis(1000)).await;
 
     // send Publish
     {
         let mut publish_uuri = create_utransport_uuri(0);
         publish_uuri.authority = Some(create_authority()).into();
+        let uuid_builder = UUIDBuilder::new();
 
-        let umessage = UMessageBuilder::publish(&publish_uuri)
+        let umessage = UMessageBuilder::publish(publish_uuri.clone())
+            .with_message_id(uuid_builder.build())
             .build_with_payload(
-                &UUIDBuilder::new(),
                 publish_data.as_bytes().to_vec().into(),
                 UPayloadFormat::UPAYLOAD_FORMAT_TEXT,
             )
             .unwrap();
+
         upclient2.send(umessage).await.unwrap();
 
         // Waiting for the subscriber to receive data
-        task::sleep(time::Duration::from_millis(1000)).await;
+        task::sleep(time::Duration::from_millis(2000)).await;
     }
     // send Request
     {
@@ -470,8 +624,8 @@ async fn test_register_listener_with_special_uuri() {
     }
 
     // Cleanup
-    upclient1
-        .unregister_listener(listener_uuri, &listener_string)
-        .await
-        .unwrap();
+    let unregister_res = upclient1
+        .unregister_listener(listener_uuri.clone(), &listener)
+        .await;
+    assert_eq!(unregister_res, Ok(()));
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -16,9 +16,9 @@ use std::{sync::Arc, time};
 use up_client_zenoh::UPClientZenoh;
 use up_rust::ulistener::UListener;
 use up_rust::{
-    CallOptionsBuilder, Data, Number, RpcClient, UAuthority, UCode, UEntity, UMessage,
-    UMessageBuilder, UMessageType, UPayload, UPayloadFormat, UResource, UResourceBuilder, UStatus,
-    UTransport, UUIDBuilder, UUri,
+    CallOptionsBuilder, Data, Number, RpcClient, UAuthority, UEntity, UMessage, UMessageBuilder,
+    UMessageType, UPayload, UPayloadFormat, UResource, UResourceBuilder, UStatus, UTransport,
+    UUIDBuilder, UUri,
 };
 use zenoh::config::Config;
 
@@ -140,13 +140,7 @@ async fn test_utransport_register_and_unregister() {
     let result = upclient
         .unregister_listener(uuri.clone(), &foo_listener)
         .await;
-    assert_eq!(
-        result,
-        Err(UStatus::fail_with_code(
-            UCode::NOT_FOUND,
-            format!("No listeners registered for topic: {:?}", &uuri),
-        ))
-    );
+    assert!(result.is_err());
 }
 
 #[async_std::test]
@@ -198,13 +192,7 @@ async fn test_utransport_special_uuri_register_and_unregister() {
     let result = upclient
         .unregister_listener(uuri.clone(), &foo_listener)
         .await;
-    assert_eq!(
-        result,
-        Err(UStatus::fail_with_code(
-            UCode::NOT_FOUND,
-            format!("No listeners registered for topic: {:?}", &uuri),
-        ))
-    );
+    assert!(result.is_err());
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Hey @evshary :wave: 

A second attempt to bring `UListener` based on my updated understanding that we should be registering and unregistering based on _specific instances_ of a UListener. This PR replaces #18

Still a WIP, but I will finish it.

I strongly want to test out the change I made to `up-rust` to align closer to the spec for uP-L1, which includes the `UListener` interface.

So far, so good with the parts I have modified and tested thus far:
* UTransport
* tests for UTransport

Still remaining to do:
- [x] update rpc.rs
- [x] update rpc tests
- [x] get all integration tests working again
- [ ] point Cargo.toml for `up-rust` back to main repo if we think the approach taken in that PR is reasonable (waiting on discrussion / review / approval of the [`up-rust` PR](https://github.com/eclipse-uprotocol/up-rust/pull/69))

And hey -- as a side benefit `up-client-zenoh-rust` would be updated to agree with the latest in the `up-rust` repo :slightly_smiling_face: 