### PR TITLE
Initialize UPClientZenoh with different configurations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,25 @@ pub type UtransportListener = Box<dyn Fn(Result<UMessage, UStatus>) + Send + Syn
 
 const UATTRIBUTE_VERSION: u8 = 1;
 
+pub enum ZenohMode {
+    Peer,
+    Client,
+    Router,
+}
+
+/// Configuration struct for `UPClientZenoh`
+pub struct UPClientZenohConfig {
+    /// The Zenoh's mode (router, peer or client)
+    pub mode: ZenohMode,
+    /// Which endpoints to listen on. E.g. tcp/localhost:7447.
+    /// By configuring the endpoints, it is possible to tell Zenoh which are the endpoints that other routers,
+    /// peers, or client can use to establish a zenoh session.
+    pub listen: Option<Vec<String>>,
+    /// Which endpoints to connect to. E.g. tcp/localhost:7447.
+    /// By configuring the endpoints, it is possible to tell Zenoh which router/peer to connect to at startup.
+    pub connect: Option<Vec<String>>,
+}
+
 pub struct ZenohListener {}
 pub struct UPClientZenoh {
     session: Arc<Session>,
@@ -47,9 +66,107 @@ pub struct UPClientZenoh {
 }
 
 impl UPClientZenoh {
+    /// Create `UPClientZenoh`
+    ///
     /// # Errors
-    /// Will return `Err` if unable to create Zenoh session
-    pub async fn new(config: Config) -> Result<UPClientZenoh, UStatus> {
+    /// Will return `Err` if unable to create `UPClientZenoh`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use up_client_zenoh::UPClientZenoh;
+    /// async_std::task::block_on(async {
+    ///     let upclient = UPClientZenoh::new().await.unwrap();
+    /// });
+    /// ```
+    pub async fn new() -> Result<UPClientZenoh, UStatus> {
+        UPClientZenoh::new_with_zenoh_config(Config::default()).await
+    }
+
+    /// Create `UPClientZenoh` by applying the `UPClientZenohConfig`
+    ///
+    /// # Arguments
+    ///
+    /// * `config` - The config needed by `UPClientZenoh`
+    ///
+    /// # Errors
+    /// Will return `Err` if unable to create `UPClientZenoh`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use up_client_zenoh::{UPClientZenoh, UPClientZenohConfig, ZenohMode};
+    /// async_std::task::block_on(async {
+    ///     let config = UPClientZenohConfig {
+    ///         mode: ZenohMode::Peer,
+    ///         connect: None,
+    ///         listen: None,
+    ///     };
+    ///     let upclient = UPClientZenoh::new_with_config(config).await.unwrap();
+    /// });
+    /// ```
+    pub async fn new_with_config(config: UPClientZenohConfig) -> Result<UPClientZenoh, UStatus> {
+        let mut zenoh_config = Config::default();
+        // Set Zenoh mode
+        zenoh_config
+            .set_mode(Some(match config.mode {
+                ZenohMode::Peer => WhatAmI::Peer,
+                ZenohMode::Client => WhatAmI::Client,
+                ZenohMode::Router => WhatAmI::Router,
+            }))
+            .map_err(|_| UStatus::fail_with_code(UCode::INTERNAL, "Unable to set Zenoh mode"))?;
+        // Parse connect address
+        if let Some(connects) = config.connect {
+            zenoh_config.connect.endpoints = connects
+                .iter()
+                .map(|v| {
+                    v.parse().map_err(|_| {
+                        UStatus::fail_with_code(
+                            UCode::INVALID_ARGUMENT,
+                            "Connect address are wrong format",
+                        )
+                    })
+                })
+                .collect::<Result<_, _>>()?;
+        }
+        // Parse listen address
+        if let Some(listens) = config.listen {
+            zenoh_config.listen.endpoints = listens
+                .iter()
+                .map(|v| {
+                    v.parse().map_err(|_| {
+                        UStatus::fail_with_code(
+                            UCode::INVALID_ARGUMENT,
+                            "Listen address are wrong format",
+                        )
+                    })
+                })
+                .collect::<Result<_, _>>()?;
+        }
+        UPClientZenoh::new_with_zenoh_config(Config::default()).await
+    }
+
+    /// Create `UPClientZenoh` by applying the Zenoh configuration.
+    /// It is suggested to use by advanced users.
+    /// You can refer to [here](https://github.com/eclipse-zenoh/zenoh/blob/0.10.1-rc/DEFAULT_CONFIG.json5) for more configuration details.
+    ///
+    /// # Arguments
+    ///
+    /// * `config` - Zenoh configuration
+    ///
+    /// # Errors
+    /// Will return `Err` if unable to create `UPClientZenoh`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use up_client_zenoh::UPClientZenoh;
+    /// use zenoh::config::Config;
+    /// async_std::task::block_on(async {
+    ///     let upclient = UPClientZenoh::new_with_zenoh_config(Config::default()).await.unwrap();
+    /// });
+    /// ```
+    pub async fn new_with_zenoh_config(config: Config) -> Result<UPClientZenoh, UStatus> {
         let Ok(session) = zenoh::open(config).res().await else {
             return Err(UStatus::fail_with_code(
                 UCode::INTERNAL,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -24,7 +24,6 @@ use up_rust::{
     uri::builder::resourcebuilder::UResourceBuilder,
     uuid::builder::UUIDBuilder,
 };
-use zenoh::config::Config;
 
 fn create_utransport_uuri(index: u8) -> UUri {
     if index == 1 {
@@ -103,7 +102,7 @@ fn create_special_uuri() -> UUri {
 
 #[async_std::test]
 async fn test_utransport_register_and_unregister() {
-    let upclient = UPClientZenoh::new(Config::default()).await.unwrap();
+    let upclient = UPClientZenoh::new().await.unwrap();
     let uuri = create_utransport_uuri(0);
 
     // Compare the return string
@@ -134,7 +133,7 @@ async fn test_utransport_register_and_unregister() {
 
 #[async_std::test]
 async fn test_rpcserver_register_and_unregister() {
-    let upclient = UPClientZenoh::new(Config::default()).await.unwrap();
+    let upclient = UPClientZenoh::new().await.unwrap();
     let uuri = create_rpcserver_uuri();
 
     // Compare the return string
@@ -165,7 +164,7 @@ async fn test_rpcserver_register_and_unregister() {
 
 #[async_std::test]
 async fn test_utransport_special_uuri_register_and_unregister() {
-    let upclient = UPClientZenoh::new(Config::default()).await.unwrap();
+    let upclient = UPClientZenoh::new().await.unwrap();
     let uuri = create_special_uuri();
 
     // Compare the return string
@@ -200,7 +199,7 @@ async fn test_utransport_special_uuri_register_and_unregister() {
 #[async_std::test]
 async fn test_publish_and_subscribe() {
     let target_data = String::from("Hello World!");
-    let upclient = UPClientZenoh::new(Config::default()).await.unwrap();
+    let upclient = UPClientZenoh::new().await.unwrap();
     let uuri = create_utransport_uuri(0);
 
     // Register the listener
@@ -245,7 +244,7 @@ async fn test_publish_and_subscribe() {
 #[async_std::test]
 async fn test_notification_and_subscribe() {
     let target_data = String::from("Hello World!");
-    let upclient = UPClientZenoh::new(Config::default()).await.unwrap();
+    let upclient = UPClientZenoh::new().await.unwrap();
     let uuri = create_utransport_uuri(1);
 
     // Register the listener
@@ -289,8 +288,8 @@ async fn test_notification_and_subscribe() {
 
 #[async_std::test]
 async fn test_rpc_server_client() {
-    let upclient_client = UPClientZenoh::new(Config::default()).await.unwrap();
-    let upclient_server = Arc::new(UPClientZenoh::new(Config::default()).await.unwrap());
+    let upclient_client = UPClientZenoh::new().await.unwrap();
+    let upclient_server = Arc::new(UPClientZenoh::new().await.unwrap());
     let request_data = String::from("This is the request data");
     let response_data = String::from("This is the response data");
     let uuri = create_rpcserver_uuri();
@@ -370,9 +369,9 @@ async fn test_rpc_server_client() {
 
 #[async_std::test]
 async fn test_register_listener_with_special_uuri() {
-    let upclient1 = Arc::new(UPClientZenoh::new(Config::default()).await.unwrap());
+    let upclient1 = Arc::new(UPClientZenoh::new().await.unwrap());
     let upclient1_clone = upclient1.clone();
-    let upclient2 = UPClientZenoh::new(Config::default()).await.unwrap();
+    let upclient2 = UPClientZenoh::new().await.unwrap();
     // Create data
     let publish_data = String::from("Hello World!");
     let publish_data_clone = publish_data.clone();


### PR DESCRIPTION
As discussed in https://github.com/eclipse-uprotocol/up-spec/issues/85
we should provide a way for users to add configuration into `UPClientZenoh`.

Now we have three ways:
* `UPClientZenoh::new()`: Using default configuration
* `UPClientZenoh::new_with_config(config: UPClientZenohConfig)`: Using UPClientZenohConfig, which is simpler and limited
* `UPClientZenoh::new_with_zenoh_config(config: Config)`: Using Zenoh config, which is mainly for advanced users

I created the PR to discuss whether this is what we want.