### PR TITLE
Fix timeout issue in RPC

### DIFF
--- a/src/utransport.rs
+++ b/src/utransport.rs
@@ -217,7 +217,7 @@ impl UPClientZenoh {
             .query_map
             .lock()
             .unwrap()
-            .get(&reqid)
+            .remove(&reqid)
             .ok_or_else(|| {
                 let msg = "query doesn't exist".to_string();
                 log::error!("{msg}");

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -95,8 +95,8 @@ impl UListener for ResponseListener {
             panic!("The message should be Data::Value type.");
         }
     }
-    async fn on_error(&self, _err: UStatus) {
-        //panic!("Internal Error: {err:?}");
+    async fn on_error(&self, err: UStatus) {
+        panic!("Internal Error: {err:?}");
     }
 }
 
@@ -173,7 +173,7 @@ async fn test_rpc_server_client(dst_uuri: UUri, listen_uuri: UUri) {
         upclient_client.send(umessage).await.unwrap();
 
         // Waiting for the callback to process data
-        task::sleep(time::Duration::from_millis(5000)).await;
+        task::sleep(time::Duration::from_millis(2000)).await;
 
         // Compare the result
         assert_eq!(response_listener.get_response_data(), response_data);


### PR DESCRIPTION
In Zenoh, if the query doesn't be destroyed after replying, the queryable will reply with timeout.
While send_response, we should also remove the query from HashMap.